### PR TITLE
Prefer provisionaccount to provision_account everywhere

### DIFF
--- a/shared-services/README.md
+++ b/shared-services/README.md
@@ -59,8 +59,8 @@ future changes by simply running `terraform apply
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-------:|:--------:|
 | aws_region | The AWS region where the non-global resources for this account are to be created (e.g. us-east-1). | string | `us-east-1` | no |
-| provision_account_role_description | The description to associate with the IAM role (as well as the corresponding policy) that allows sufficient access to provision all AWS resources in this account. | string | `Allows sufficient access to provision all AWS resources in this account.` | no |
-| provision_account_role_name | The name to assign the IAM role (as well as the corresponding policy) that allows sufficient permissions to provision all AWS resources in the terraform account. | string | `ProvisionAccount` | no |
+| provisionaccount_role_description | The description to associate with the IAM role (as well as the corresponding policy) that allows sufficient access to provision all AWS resources in this account. | string | `Allows sufficient access to provision all AWS resources in this account.` | no |
+| provisionaccount_role_name | The name to assign the IAM role (as well as the corresponding policy) that allows sufficient permissions to provision all AWS resources in the terraform account. | string | `ProvisionAccount` | no |
 | tags | Tags to apply to all AWS resources created. | map(string) | `{}` | no |
 | this_account_id | The ID of the account being configured. | string | | yes |
 | user_account_id | The ID of the users account.  This account will be allowed to assume the role that allows sufficient access to the Terraform S3 bucket and DynamoDB table to use those resources as a Terraform backend. | string | | yes |
@@ -69,7 +69,7 @@ future changes by simply running `terraform apply
 
 | Name | Description |
 |------|-------------|
-| provision_account_role_arn | The ARN of the IAM role that allows sufficient permissions to create all AWS resources in this account. |
+| provisionaccount_role_arn | The ARN of the IAM role that allows sufficient permissions to create all AWS resources in this account. |
 
 ## Contributing ##
 

--- a/shared-services/outputs.tf
+++ b/shared-services/outputs.tf
@@ -1,4 +1,4 @@
-output "provision_account_role_arn" {
-  value       = aws_iam_role.provision_account_role.arn
+output "provisionaccount_role_arn" {
+  value       = aws_iam_role.provisionaccount_role.arn
   description = "The ARN of the IAM role that allows sufficient permissions to provision all AWS resources in this account."
 }

--- a/shared-services/provider.tf
+++ b/shared-services/provider.tf
@@ -2,7 +2,7 @@ provider "aws" {
   region = var.aws_region
   # Use this role once the account has been bootstrapped.
   # assume_role {
-  #   role_arn = "arn:aws:iam::${var.this_account_id}:role/${var.provision_account_role_name}"
+  #   role_arn = "arn:aws:iam::${var.this_account_id}:role/${var.provisionaccount_role_name}"
   # }
   # Use this profile, defined using programmatic credentials for
   # AWSAdministratorAccess as obtained for the COOL terraform account

--- a/shared-services/provision_role.tf
+++ b/shared-services/provision_role.tf
@@ -3,14 +3,14 @@
 # all AWS resources in the terraform account.
 # ------------------------------------------------------------------------------
 
-resource "aws_iam_role" "provision_account_role" {
+resource "aws_iam_role" "provisionaccount_role" {
   assume_role_policy = data.aws_iam_policy_document.assume_role_doc.json
-  description        = var.provision_account_role_description
-  name               = var.provision_account_role_name
+  description        = var.provisionaccount_role_description
+  name               = var.provisionaccount_role_name
   tags               = var.tags
 }
 
 resource "aws_iam_role_policy_attachment" "iamfullaccess_policy_attachment" {
   policy_arn = "arn:aws:iam::aws:policy/IAMFullAccess"
-  role       = aws_iam_role.provision_account_role.name
+  role       = aws_iam_role.provisionaccount_role.name
 }

--- a/shared-services/variables.tf
+++ b/shared-services/variables.tf
@@ -23,12 +23,12 @@ variable "aws_region" {
   default     = "us-east-1"
 }
 
-variable "provision_account_role_description" {
+variable "provisionaccount_role_description" {
   description = "The description to associate with the IAM role (as well as the corresponding policy) that allows sufficient permissions to provision all AWS resources in this account."
   default     = "Allows sufficient permissions to provision all AWS resources in this account."
 }
 
-variable "provision_account_role_name" {
+variable "provisionaccount_role_name" {
   description = "The name to assign the IAM role (as well as the corresponding policy) that allows sufficient permissions to provision all AWS resources in the terraform account."
   default     = "ProvisionAccount"
 }

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -75,8 +75,8 @@ future changes by simply running `terraform apply
 | access_terraform_backend_role_description | The description to associate with the IAM role (as well as the corresponding policy) that allows sufficient access to the Terraform S3 bucket and DynamoDB table to use those resources as a Terraform backend. | string | `Allows sufficient access to the Terraform S3 bucket and DynamoDB table to use those resources as a Terraform backend.` | no |
 | access_terraform_backend_role_name | The name to assign the IAM role (as well as the corresponding policy) that allows sufficient access to the Terraform S3 bucket and DynamoDB table to use those resources as a Terraform backend. | string | `AccessTerraformBackend` | no |
 | aws_region | The AWS region where the non-global resources for this account are to be provisioned (e.g. us-east-1). | string | `us-east-1` | no |
-| provision_account_role_description | The description to associate with the IAM role (as well as the corresponding policy) that allows sufficient access to provision all AWS resources in this account. | string | `Allows sufficient access to provision all AWS resources in this account.` | no |
-| provision_account_role_name | The name to assign the IAM role (as well as the corresponding policy) that allows sufficient permissions to provision all AWS resources in the terraform account. | string | `ProvisionAccount` | no |
+| provisionaccount_role_description | The description to associate with the IAM role (as well as the corresponding policy) that allows sufficient access to provision all AWS resources in this account. | string | `Allows sufficient access to provision all AWS resources in this account.` | no |
+| provisionaccount_role_name | The name to assign the IAM role (as well as the corresponding policy) that allows sufficient permissions to provision all AWS resources in the terraform account. | string | `ProvisionAccount` | no |
 | state_bucket_name | The name to use for the S3 bucket that will store the Terraform state. | string | `cisa-cool-terraform-state` | no |
 | state_table_name | The name to use for the DynamoDB table that will be used for Terraform state locking. | string | `terraform-state-lock` | no |
 | state_table_read_capacity | The number of read units for the DynamoDB table that will be used for Terraform state locking. | number | `20` | no |
@@ -90,7 +90,7 @@ future changes by simply running `terraform apply
 | Name | Description |
 |------|-------------|
 | access_terraform_backend_role_arn | The ARN of the IAM role that allows sufficient access to the Terraform S3 bucket and DynamoDB table to use those resources as a Terraform backend. |
-| provision_account_role_arn | The ARN of the IAM role that allows sufficient permissions to provision all AWS resources in this account. |
+| provisionaccount_role_arn | The ARN of the IAM role that allows sufficient permissions to provision all AWS resources in this account. |
 | state_bucket_arn | The ARN of the S3 bucket where Terraform state information will be stored. |
 | state_bucket_id | The ID of the S3 bucket where Terraform state information will be stored. |
 | state_lock_table_arn | The ARN of the DynamoDB table that to be used for Terraform state locking. |

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -3,8 +3,8 @@ output "access_terraform_backend_role_arn" {
   description = "The ARN of the IAM role that allows sufficient access to the Terraform S3 bucket and DynamoDB table to use those resources as a Terraform backend."
 }
 
-output "provision_account_role_arn" {
-  value       = aws_iam_role.provision_account_role.arn
+output "provisionaccount_role_arn" {
+  value       = aws_iam_role.provisionaccount_role.arn
   description = "The ARN of the IAM role that allows sufficient permissions to provision all AWS resources in this account."
 }
 

--- a/terraform/provider.tf
+++ b/terraform/provider.tf
@@ -2,7 +2,7 @@ provider "aws" {
   region = var.aws_region
   # Use this role once the account has been bootstrapped.
   assume_role {
-    role_arn = "arn:aws:iam::${var.this_account_id}:role/${var.provision_account_role_name}"
+    role_arn = "arn:aws:iam::${var.this_account_id}:role/${var.provisionaccount_role_name}"
   }
   # Use this profile, defined using programmatic credentials for
   # AWSAdministratorAccess as obtained for the COOL terraform account

--- a/terraform/provision_policy.tf
+++ b/terraform/provision_policy.tf
@@ -6,7 +6,7 @@
 # We will also attach the IAMFullAccess policy to the role that uses
 # this policy, so it will have all necessary permissions to provision
 # all AWS resources in the terraform account.
-data "aws_iam_policy_document" "provision_account_doc" {
+data "aws_iam_policy_document" "provisionaccount_doc" {
   # Permissions necessary to manipulate the state bucket
   statement {
     actions = [
@@ -29,8 +29,8 @@ data "aws_iam_policy_document" "provision_account_doc" {
 }
 
 # The IAM policy
-resource "aws_iam_policy" "provision_account_policy" {
-  description = var.provision_account_role_description
-  name        = var.provision_account_role_name
-  policy      = data.aws_iam_policy_document.provision_account_doc.json
+resource "aws_iam_policy" "provisionaccount_policy" {
+  description = var.provisionaccount_role_description
+  name        = var.provisionaccount_role_name
+  policy      = data.aws_iam_policy_document.provisionaccount_doc.json
 }

--- a/terraform/provision_role.tf
+++ b/terraform/provision_role.tf
@@ -3,20 +3,20 @@
 # all AWS resources in the terraform account.
 # ------------------------------------------------------------------------------
 
-resource "aws_iam_role" "provision_account_role" {
+resource "aws_iam_role" "provisionaccount_role" {
   assume_role_policy = data.aws_iam_policy_document.assume_role_doc.json
-  description        = var.provision_account_role_description
-  name               = var.provision_account_role_name
+  description        = var.provisionaccount_role_description
+  name               = var.provisionaccount_role_name
   tags               = var.tags
 }
 
 # Attach the desired IAM policies to the role
-resource "aws_iam_role_policy_attachment" "provision_account_policy_attachment" {
-  policy_arn = aws_iam_policy.provision_account_policy.arn
-  role       = aws_iam_role.provision_account_role.name
+resource "aws_iam_role_policy_attachment" "provisionaccount_policy_attachment" {
+  policy_arn = aws_iam_policy.provisionaccount_policy.arn
+  role       = aws_iam_role.provisionaccount_role.name
 }
 
 resource "aws_iam_role_policy_attachment" "iamfullaccess_policy_attachment" {
   policy_arn = "arn:aws:iam::aws:policy/IAMFullAccess"
-  role       = aws_iam_role.provision_account_role.name
+  role       = aws_iam_role.provisionaccount_role.name
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -33,12 +33,12 @@ variable "aws_region" {
   default     = "us-east-1"
 }
 
-variable "provision_account_role_description" {
+variable "provisionaccount_role_description" {
   description = "The description to associate with the IAM role (as well as the corresponding policy) that allows sufficient permissions to provision all AWS resources in this account."
   default     = "Allows sufficient permissions to provision all AWS resources in this account."
 }
 
-variable "provision_account_role_name" {
+variable "provisionaccount_role_name" {
   description = "The name to assign the IAM role (as well as the corresponding policy) that allows sufficient permissions to provision all AWS resources in the terraform account."
   default     = "ProvisionAccount"
 }


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description

This pull request changes variable names, output names, Terraform resource names, etc. to use `provisionaccount` instead `provision_account`.

## 💭 Motivation and Context

@dav3r and I discussed doing this, and then neither of us actually did it.  Making this change will result in greater naming consistency throughout the code.

## 🧪 Testing

I verified that the pre-commit hooks all pass.

## 🚥 Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
