### PR TITLE
Modify README to not use local state for any account other than the "terraform" account

### DIFF
--- a/shared-services/README.md
+++ b/shared-services/README.md
@@ -46,9 +46,9 @@ To do this, follow these steps:
 1. Run the command `terraform apply
    -var-file=<workspace_name>.tfvars`.
 1. Revert the changes you made to `provider.tf` in step 1.
-1. Run the command `terraform init`.
-1. Run the command `terraform apply
-    -var-file=<workspace_name>.tfvars`.
+1. Run the command `terraform apply -var-file=<workspace_name>.tfvars`
+   and verify that Terraform does not want to add, remove, or modify
+   any resources.
 
 At this point the account has been bootstrapped, and you can apply
 future changes by simply running `terraform apply

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -61,8 +61,9 @@ To do this, follow these steps:
 1. Revert the changes you made to `backend.tf` in step 1.
 1. Revert the changes you made to `provider.tf` in step 2.
 1. Run the command `terraform init`.
-1. Run the command `terraform apply
-    -var-file=<workspace_name>.tfvars`.
+1. Run the command `terraform apply -var-file=<workspace_name>.tfvars`
+   and verify that Terraform does not want to add, remove, or modify
+   any resources.
 
 At this point the account has been bootstrapped, and you can apply
 future changes by simply running `terraform apply

--- a/users/README.md
+++ b/users/README.md
@@ -13,18 +13,17 @@ This subdirectory contains Terraform code to provision the COOL
 
 Note that this account must be bootstrapped after the "terraform"
 account.  This is because initially there are no resources in this
-account that can access the remote shared Terraform state, and
-also because there is no IAM role that can be assumed to build out
-those resources.  Therefore you must first apply this Terraform code
-with:
-
-* No backend configuration, so that the state is created locally.
-* Using programmatic credentials for AWSAdministratorAccess as
-  obtained for the COOL "users" account from the AWS SSO page.
+account that can access the remote shared Terraform state, and also
+because there is no IAM role that can be assumed to build out those
+resources.  Therefore you must first apply this Terraform code using
+programmatic credentials for AWSAdministratorAccess as obtained for
+the COOL "terraform" and "users" accounts from the AWS SSO page.
 
 To do this, follow these steps:
 
-1. Comment out all the content in the `backend.tf` file.
+1. Comment out the `profile = "cool-terraform-backend"` line in the
+   `backend.tf` file.  Directly below that, uncomment the `profile =
+   "cool-terraform-account-admin"` line.
 1. Comment out the `assume_role` block in `provider.tf` and directly
    below that uncomment the line `profile = "cool-users-account-admin"`.
 1. Create a new AWS profile called `cool-users-account-admin` in
@@ -62,8 +61,9 @@ To do this, follow these steps:
 1. Revert the changes you made to `backend.tf` in step 1.
 1. Revert the changes you made to `provider.tf` in step 2.
 1. Run the command `terraform init`.
-1. Run the command `terraform apply
-    -var-file=<workspace_name>.tfvars`.
+1. Run the command `terraform apply -var-file=<workspace_name>.tfvars`
+   and verify that Terraform does not want to add, remove, or modify
+   any resources.
 
 At this point the account has been bootstrapped, and you can apply
 future changes by simply running `terraform apply

--- a/users/backend.tf
+++ b/users/backend.tf
@@ -5,8 +5,15 @@ terraform {
     encrypt        = true
     bucket         = "cisa-cool-terraform-state"
     dynamodb_table = "terraform-state-lock"
-    profile        = "cool-terraform-backend"
-    region         = "us-east-1"
-    key            = "cool-accounts/users.tfstate"
+    # Use this profile once the account has been bootstrapped.
+    profile = "cool-terraform-backend"
+    # Use the profile below, defined using programmatic credentials
+    # for AWSAdministratorAccess as obtained for the COOL "users"
+    # account from the AWS SSO page, to bootstrap the account.
+    # Comment out this profile below after this account has been
+    # bootstrapped.
+    # profile = "cool-terraform-account-admin"
+    region = "us-east-1"
+    key    = "cool-accounts/users.tfstate"
   }
 }


### PR DESCRIPTION
## 🗣 Description

After a discussion with @dav3r, it occurred to me that there is no need to start out with local state for any account other than the "terraform" account when bootstrapping.  One can instead simply configure the backend to temporarily use programmatic credentials for AWSAdministratorAccess as obtained for the COOL "terraform" and "users" accounts from the AWS SSO page.

## 💭 Motivation and Context

This doesn't greatly reduce the number of steps required to bootstrap the accounts, but it does reduce the cognitive load since the starting state is more similar to the final state.  Therefore I think it's a good change to make.

## 🧪 Testing

The changes are really just documentation changes, but I did make sure that the pre-commit hooks all passed.

## 🚥 Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
