### PR TITLE
Add the admin users to the Shared Services provisioners group

### DIFF
--- a/users/group_membership.tf
+++ b/users/group_membership.tf
@@ -6,8 +6,9 @@ resource "aws_iam_user_group_membership" "admin_user" {
   user = aws_iam_user.admin_user[count.index].name
 
   groups = [
+    aws_iam_group.sharedservices_account_provisioners.name,
+    aws_iam_group.terraform_account_provisioners.name,
     aws_iam_group.terraform_backend_users.name,
-    aws_iam_group.users_account_provisioners.name,
-    aws_iam_group.terraform_account_provisioners.name
+    aws_iam_group.users_account_provisioners.name
   ]
 }


### PR DESCRIPTION
## 🗣 Description

In this pull request, I add the admin users to the Shared Services provisioners group.  I thought I had done this in #3 but it seems I overlooked it.  Mea culpa.

While I'm at it, I go ahead and alphabetize the list of groups in the Terraform code.

## 💭 Motivation and Context

This must be done so I can Terraform the Shared Services account via my COOL user IAM account.

## 🧪 Testing

I applied these changes to COOL production and they worked.  The proof is in the pudding!

I verified that the pre-commit hooks all pass as well.

## 🚥 Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
