### PR TITLE
Use a map for admin usernames, rather than a list

### DIFF
--- a/users/README.md
+++ b/users/README.md
@@ -73,7 +73,7 @@ future changes by simply running `terraform apply
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-------:|:--------:|
-| admin_usernames | The usernames associated with the admin accounts to be created, which are allowed to access the terraform backend and are IAM administrators.  The format first.last is recommended. | string | | yes |
+| admin_usernames | The usernames associated with the admin accounts to be created, which are allowed to access the terraform backend and are IAM administrators.  The format first.last is recommended.  The keys are the usernames and the values are empty strings (since they are not presently used). Example: { \"firstname1.lastname1\" = \"\",  \"firstname2.lastname2\" = \"\" } | map(string) | | yes |
 | assume_access_terraform_backend_policy_description | The description to associate with the IAM policy that allows assumption of the role with access to the Terraform backend | string | `Allow assumption of the AccessTerraformBackend role in the Terraform account.` | no |
 | assume_access_terraform_backend_policy_name | The name to assign the IAM policy that allows assumption of the role with access to the Terraform backend | string | `Terraform-AssumeAccessTerraformBackend` | no |
 | assume_provisionaccount_policy_description | The description to associate with the IAM policy that allows assumption of the role to provision all AWS resources in this account | string | `Allow assumption of the ProvisionAccount role.` | no |

--- a/users/group_membership.tf
+++ b/users/group_membership.tf
@@ -1,9 +1,9 @@
 # Put our admin IAM users in the Terraform backend access, IAM admin, and
 # Terraform account provisioners groups.
 resource "aws_iam_user_group_membership" "admin_user" {
-  count = length(var.admin_usernames)
+  for_each = var.admin_usernames
 
-  user = aws_iam_user.admin_user[count.index].name
+  user = aws_iam_user.admin_user[each.key].name
 
   groups = [
     aws_iam_group.sharedservices_account_provisioners.name,

--- a/users/iam_admin_users.tf
+++ b/users/iam_admin_users.tf
@@ -1,8 +1,8 @@
 # The admin users being created
 resource "aws_iam_user" "admin_user" {
-  count = length(var.admin_usernames)
+  for_each = var.admin_usernames
 
-  name = var.admin_usernames[count.index]
+  name = each.key
   tags = var.tags
 }
 
@@ -13,7 +13,7 @@ resource "aws_iam_user" "admin_user" {
 # with MFA, since these accounts will only be accessed programatically
 # (i.e. not via the AWS web console) where MFA is not an option.
 data "aws_iam_policy_document" "admin_iam_self_admin_doc" {
-  count = length(var.admin_usernames)
+  for_each = var.admin_usernames
 
   # Allow users to view their own account information
   statement {
@@ -40,7 +40,7 @@ data "aws_iam_policy_document" "admin_iam_self_admin_doc" {
     ]
 
     resources = [
-      aws_iam_user.admin_user[count.index].arn,
+      aws_iam_user.admin_user[each.key].arn,
     ]
   }
 
@@ -56,7 +56,7 @@ data "aws_iam_policy_document" "admin_iam_self_admin_doc" {
     ]
 
     resources = [
-      aws_iam_user.admin_user[count.index].arn,
+      aws_iam_user.admin_user[each.key].arn,
     ]
   }
 
@@ -72,7 +72,7 @@ data "aws_iam_policy_document" "admin_iam_self_admin_doc" {
     ]
 
     resources = [
-      aws_iam_user.admin_user[count.index].arn,
+      aws_iam_user.admin_user[each.key].arn,
     ]
   }
 
@@ -89,7 +89,7 @@ data "aws_iam_policy_document" "admin_iam_self_admin_doc" {
     ]
 
     resources = [
-      aws_iam_user.admin_user[count.index].arn,
+      aws_iam_user.admin_user[each.key].arn,
     ]
   }
 
@@ -106,7 +106,7 @@ data "aws_iam_policy_document" "admin_iam_self_admin_doc" {
     ]
 
     resources = [
-      aws_iam_user.admin_user[count.index].arn,
+      aws_iam_user.admin_user[each.key].arn,
     ]
   }
 
@@ -122,7 +122,7 @@ data "aws_iam_policy_document" "admin_iam_self_admin_doc" {
     resources = [
       # The MFA ARN is identical to that of the user, except that the
       # text "user" is replaced by "mfa"
-      replace(aws_iam_user.admin_user[count.index].arn, "user", "mfa"),
+      replace(aws_iam_user.admin_user[each.key].arn, "user", "mfa"),
     ]
   }
 
@@ -138,16 +138,16 @@ data "aws_iam_policy_document" "admin_iam_self_admin_doc" {
     ]
 
     resources = [
-      aws_iam_user.admin_user[count.index].arn,
+      aws_iam_user.admin_user[each.key].arn,
     ]
   }
 }
 
 # The IAM self-administration policy for our IAM users
 resource "aws_iam_user_policy" "admin_user" {
-  count = length(var.admin_usernames)
+  for_each = var.admin_usernames
 
   name   = "SelfManagedCredsWithoutMFA"
-  user   = aws_iam_user.admin_user[count.index].name
-  policy = data.aws_iam_policy_document.admin_iam_self_admin_doc[count.index].json
+  user   = each.key
+  policy = data.aws_iam_policy_document.admin_iam_self_admin_doc[each.key].json
 }

--- a/users/variables.tf
+++ b/users/variables.tf
@@ -5,8 +5,8 @@
 # ------------------------------------------------------------------------------
 
 variable "admin_usernames" {
-  type        = list(string)
-  description = "The usernames associated with the admin accounts to be created, which are allowed to access the terraform backend and are IAM administrators.  The format first.last is recommended."
+  type        = map(string)
+  description = "The usernames associated with the admin accounts to be created, which are allowed to access the terraform backend and are IAM administrators.  The format first.last is recommended.  The keys are the usernames and the values are empty strings (since they are not presently used). Example: { \"firstname1.lastname1\" = \"\",  \"firstname2.lastname2\" = \"\" }"
 }
 
 variable "sharedservices_account_id" {


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description

This PR modifies the `admin_usernames` variable from a `list` to a `map`.

## 💭 Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The primary goal here is to avoid having terraform unnecessarily destroy/re-create admin users (and related resources like group membership) whenever the group of admin usernames are modified.  

Presently, if the first admin user in the list is deleted, all of the remaining users will be destroyed and re-created by the next `terraform apply`.  By changing `admin_usernames` to a `map`, only the resources related to the user being deleted will be destroyed.  This is very important because recreating admin users is a disruptive operation (AWS programmatic creds and MFA keys must be manually deleted and recreated).

Note that our new `admin_usernames` map has usernames as keys, but empty strings for the values.  This looks a bit strange, but it accomplishes our goal of minimizing unnecessary terraforming.

## 🧪 Testing

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Similar changes were recently tested and deployed in the [cool-users-non-admin](https://github.com/cisagov/cool-users-non-admin) repo.  In this repo, I ran a `terraform plan` and manually verified that the planned changes were all expected.

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
