### PR TITLE
Remove account ID variable as an input variable

### DIFF
--- a/audit/README.md
+++ b/audit/README.md
@@ -64,7 +64,6 @@ future changes by simply running `terraform apply
 | provisionaccount_role_description | The description to associate with the IAM role (as well as the corresponding policy) that allows sufficient access to provision all AWS resources in the Audit account. | string | `Allows sufficient access to provision all AWS resources in the Audit account.` | no |
 | provisionaccount_role_name | The name to assign the IAM role (as well as the corresponding policy) that allows sufficient permissions to provision all AWS resources in the Audit account. | string | `ProvisionAccount` | no |
 | tags | Tags to apply to all AWS resources created. | map(string) | `{}` | no |
-| this_account_id | The ID of the account being configured. | string | | yes |
 | users_account_id | The ID of the users account.  This account will be allowed to assume the role that allows sufficient access to provision all AWS resources in the Audit account. | string | | yes |
 
 ## Outputs ##

--- a/audit/README.md
+++ b/audit/README.md
@@ -36,7 +36,6 @@ To do this, follow these steps:
    variables (see [Inputs](#Inputs) below for details):
 
    ```console
-   this_account_id  = "111111111111"
    users_account_id = "222222222222"
 
    admin_usernames = [

--- a/audit/provisionaccount.tf
+++ b/audit/provisionaccount.tf
@@ -1,7 +1,6 @@
 module "provisionaccount" {
   source = "../provisionaccount-role-tf-module"
 
-  new_account_id                    = var.this_account_id
   provisionaccount_role_description = var.provisionaccount_role_description
   provisionaccount_role_name        = var.provisionaccount_role_name
   tags                              = var.tags

--- a/audit/variables.tf
+++ b/audit/variables.tf
@@ -4,10 +4,6 @@
 # You must provide a value for each of these parameters.
 # ------------------------------------------------------------------------------
 
-variable "this_account_id" {
-  description = "The ID of the account being configured."
-}
-
 variable "users_account_id" {
   description = "The ID of the users account.  This account will be allowed to assume the role that allows sufficient permissions to provision all AWS resources in the Audit account."
 }

--- a/dns/README.md
+++ b/dns/README.md
@@ -36,7 +36,6 @@ To do this, follow these steps:
    variables (see [Inputs](#Inputs) below for details):
 
    ```console
-   this_account_id  = "111111111111"
    users_account_id = "222222222222"
 
    admin_usernames = [

--- a/dns/README.md
+++ b/dns/README.md
@@ -64,7 +64,6 @@ future changes by simply running `terraform apply
 | provisionaccount_role_description | The description to associate with the IAM role (as well as the corresponding policy) that allows sufficient access to provision all AWS resources in the DNS account. | string | `Allows sufficient access to provision all AWS resources in the DNS account.` | no |
 | provisionaccount_role_name | The name to assign the IAM role (as well as the corresponding policy) that allows sufficient permissions to provision all AWS resources in the DNS account. | string | `ProvisionAccount` | no |
 | tags | Tags to apply to all AWS resources created. | map(string) | `{}` | no |
-| this_account_id | The ID of the account being configured. | string | | yes |
 | users_account_id | The ID of the users account.  This account will be allowed to assume the role that allows sufficient access to provision all AWS resources in the DNS account. | string | | yes |
 
 ## Outputs ##

--- a/dns/provisionaccount.tf
+++ b/dns/provisionaccount.tf
@@ -1,7 +1,6 @@
 module "provisionaccount" {
   source = "../provisionaccount-role-tf-module"
 
-  new_account_id                    = var.this_account_id
   provisionaccount_role_description = var.provisionaccount_role_description
   provisionaccount_role_name        = var.provisionaccount_role_name
   tags                              = var.tags

--- a/dns/variables.tf
+++ b/dns/variables.tf
@@ -4,10 +4,6 @@
 # You must provide a value for each of these parameters.
 # ------------------------------------------------------------------------------
 
-variable "this_account_id" {
-  description = "The ID of the account being configured."
-}
-
 variable "users_account_id" {
   description = "The ID of the users account.  This account will be allowed to assume the role that allows sufficient permissions to provision all AWS resources in the DNS account."
 }

--- a/images/README.md
+++ b/images/README.md
@@ -41,7 +41,6 @@ To do this, follow these steps:
    variables (see [Inputs](#Inputs) below for details):
 
    ```console
-   this_account_id  = "111111111111"
    users_account_id = "222222222222"
 
    admin_usernames = [
@@ -71,7 +70,6 @@ future changes by simply running `terraform apply
 | provisionaccount_role_description | The description to associate with the IAM role (as well as the corresponding policy) that allows sufficient access to provision all AWS resources in the Images account. | string | `Allows sufficient access to provision all AWS resources in the Images account.` | no |
 | provisionaccount_role_name | The name to assign the IAM role (as well as the corresponding policy) that allows sufficient permissions to provision all AWS resources in the Images account. | string | `ProvisionAccount` | no |
 | tags | Tags to apply to all AWS resources created. | map(string) | `{}` | no |
-| this_account_id | The ID of the account being configured. | string | | yes |
 | users_account_id | The ID of the users account.  This account will be allowed to assume the role that allows sufficient access to provision all AWS resources in the Images account, as well as the role that allows sufficient permissions to create AWS EC2 AMIs in the Images account. | string | | yes |
 
 ## Outputs ##

--- a/images/provisionaccount.tf
+++ b/images/provisionaccount.tf
@@ -1,7 +1,6 @@
 module "provisionaccount" {
   source = "../provisionaccount-role-tf-module"
 
-  new_account_id                    = var.this_account_id
   provisionaccount_role_description = var.provisionaccount_role_description
   provisionaccount_role_name        = var.provisionaccount_role_name
   tags                              = var.tags

--- a/images/variables.tf
+++ b/images/variables.tf
@@ -4,10 +4,6 @@
 # You must provide a value for each of these parameters.
 # ------------------------------------------------------------------------------
 
-variable "this_account_id" {
-  description = "The ID of the account being configured."
-}
-
 variable "users_account_id" {
   description = "The ID of the users account.  This account will be allowed to assume the role that allows sufficient permissions to provision all AWS resources in the Images account."
 }

--- a/log-archive/README.md
+++ b/log-archive/README.md
@@ -37,7 +37,6 @@ To do this, follow these steps:
    variables (see [Inputs](#Inputs) below for details):
 
    ```console
-   this_account_id  = "111111111111"
    users_account_id = "222222222222"
 
    admin_usernames = [
@@ -65,7 +64,6 @@ future changes by simply running `terraform apply
 | provisionaccount_role_description | The description to associate with the IAM role (as well as the corresponding policy) that allows sufficient access to provision all AWS resources in the Log Archive account. | string | `Allows sufficient access to provision all AWS resources in the Log Archive account.` | no |
 | provisionaccount_role_name | The name to assign the IAM role (as well as the corresponding policy) that allows sufficient permissions to provision all AWS resources in the Log Archive account. | string | `ProvisionAccount` | no |
 | tags | Tags to apply to all AWS resources created. | map(string) | `{}` | no |
-| this_account_id | The ID of the account being configured. | string | | yes |
 | users_account_id | The ID of the users account.  This account will be allowed to assume the role that allows sufficient access to provision all AWS resources in the Log Archive account. | string | | yes |
 
 ## Outputs ##

--- a/log-archive/provisionaccount.tf
+++ b/log-archive/provisionaccount.tf
@@ -1,7 +1,6 @@
 module "provisionaccount" {
   source = "../provisionaccount-role-tf-module"
 
-  new_account_id                    = var.this_account_id
   provisionaccount_role_description = var.provisionaccount_role_description
   provisionaccount_role_name        = var.provisionaccount_role_name
   tags                              = var.tags

--- a/log-archive/variables.tf
+++ b/log-archive/variables.tf
@@ -4,10 +4,6 @@
 # You must provide a value for each of these parameters.
 # ------------------------------------------------------------------------------
 
-variable "this_account_id" {
-  description = "The ID of the account being configured."
-}
-
 variable "users_account_id" {
   description = "The ID of the users account.  This account will be allowed to assume the role that allows sufficient permissions to provision all AWS resources in the Log Archive account."
 }

--- a/master/README.md
+++ b/master/README.md
@@ -36,7 +36,6 @@ To do this, follow these steps:
    variables (see [Inputs](#Inputs) below for details):
 
    ```console
-   this_account_id  = "111111111111"
    users_account_id = "222222222222"
 
    admin_usernames = [
@@ -64,7 +63,6 @@ future changes by simply running `terraform apply
 | provisionaccount_role_description | The description to associate with the IAM role (as well as the corresponding policy) that allows sufficient access to provision all AWS resources in the Master account. | string | `Allows sufficient access to provision all AWS resources in the Master account.` | no |
 | provisionaccount_role_name | The name to assign the IAM role (as well as the corresponding policy) that allows sufficient permissions to provision all AWS resources in the Master account. | string | `ProvisionAccount` | no |
 | tags | Tags to apply to all AWS resources created. | map(string) | `{}` | no |
-| this_account_id | The ID of the account being configured. | string | | yes |
 | users_account_id | The ID of the users account.  This account will be allowed to assume the role that allows sufficient access to provision all AWS resources in the Master account. | string | | yes |
 
 ## Outputs ##

--- a/master/provisionaccount.tf
+++ b/master/provisionaccount.tf
@@ -1,7 +1,6 @@
 module "provisionaccount" {
   source = "../provisionaccount-role-tf-module"
 
-  new_account_id                    = var.this_account_id
   provisionaccount_role_description = var.provisionaccount_role_description
   provisionaccount_role_name        = var.provisionaccount_role_name
   tags                              = var.tags

--- a/master/variables.tf
+++ b/master/variables.tf
@@ -4,10 +4,6 @@
 # You must provide a value for each of these parameters.
 # ------------------------------------------------------------------------------
 
-variable "this_account_id" {
-  description = "The ID of the account being configured."
-}
-
 variable "users_account_id" {
   description = "The ID of the users account.  This account will be allowed to assume the role that allows sufficient permissions to provision all AWS resources in the Master account."
 }

--- a/provisionaccount-role-tf-module/README.md
+++ b/provisionaccount-role-tf-module/README.md
@@ -16,7 +16,6 @@ user credentials.
 module "provisionaccount" {
   source = "../provisionaccount-role-tf-module"
 
-  new_account_id                             = var.this_account_id
   provisionaccount_role_description          = "Allows sufficient permissions to provision all AWS resources in the DNS account."
   provisionaccount_role_name                 = "ProvisionAccount"
   tags                                       = {
@@ -37,7 +36,6 @@ module "provisionaccount" {
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-------:|:--------:|
 | aws_region | The AWS region where the non-global resources for this account are to be created (e.g. us-east-1). | string | `us-east-1` | no |
-| new_account_id | The ID of the account being configured. | string | | yes |
 | provisionaccount_role_description | The description to associate with the IAM role (as well as the corresponding policy) that allows sufficient access to provision all AWS resources in the new account (e.g. "Allows sufficient permissions to provision all AWS resources in the DNS account."). | string | | yes |
 | provisionaccount_role_name | The name to assign the IAM role (as well as the corresponding policy) that allows sufficient permissions to provision all AWS resources in the new account (e.g. "ProvisionAccount"). | string | | yes |
 | tags | Tags to apply to all AWS resources created. | map(string) | `{}` | no |

--- a/provisionaccount-role-tf-module/examples/basic_usage/README.md
+++ b/provisionaccount-role-tf-module/examples/basic_usage/README.md
@@ -37,7 +37,6 @@ To do this, follow these steps:
    variables (see [Inputs](#Inputs) below for details):
 
    ```console
-   this_account_id  = "111111111111"
    users_account_id = "222222222222"
 
    admin_usernames = [

--- a/provisionaccount-role-tf-module/examples/basic_usage/README.md
+++ b/provisionaccount-role-tf-module/examples/basic_usage/README.md
@@ -65,7 +65,6 @@ future changes by simply running `terraform apply
 | provisionaccount_role_description | The description to associate with the IAM role (as well as the corresponding policy) that allows sufficient access to provision all AWS resources in the Pettifogger0 account. | string | `Allows sufficient access to provision all AWS resources in the Pettifogger0 account.` | no |
 | provisionaccount_role_name | The name to assign the IAM role (as well as the corresponding policy) that allows sufficient permissions to provision all AWS resources in Pettifogger0 account. | string | `ProvisionAccount` | no |
 | tags | Tags to apply to all AWS resources created. | map(string) | `{}` | no |
-| this_account_id | The ID of the account being configured. | string | | yes |
 | users_account_id | The ID of the users account.  This account will be allowed to assume the role that allows sufficient access to provision all AWS resources in the Pettifogger0 account. | string | | yes |
 
 ## Outputs ##

--- a/provisionaccount-role-tf-module/examples/basic_usage/provisionaccount.tf
+++ b/provisionaccount-role-tf-module/examples/basic_usage/provisionaccount.tf
@@ -1,7 +1,6 @@
 module "provisionaccount" {
   source = "../provisionaccount-role-tf-module"
 
-  new_account_id                    = var.this_account_id
   provisionaccount_role_description = var.provisionaccount_role_description
   provisionaccount_role_name        = var.provisionaccount_role_name
   tags                              = var.tags

--- a/provisionaccount-role-tf-module/variables.tf
+++ b/provisionaccount-role-tf-module/variables.tf
@@ -4,10 +4,6 @@
 # You must provide a value for each of these parameters.
 # ------------------------------------------------------------------------------
 
-variable "new_account_id" {
-  description = "The ID of the account being configured."
-}
-
 variable "provisionaccount_role_description" {
   description = "The description to associate with the IAM role (as well as the corresponding policy) that allows sufficient permissions to provision all AWS resources in the new account (e.g. \"Allows sufficient permissions to provision all AWS resources in the DNS account.\")."
 }

--- a/shared-services/README.md
+++ b/shared-services/README.md
@@ -37,7 +37,6 @@ To do this, follow these steps:
    variables (see [Inputs](#Inputs) below for details):
 
    ```console
-   this_account_id  = "111111111111"
    users_account_id = "222222222222"
 
    admin_usernames = [
@@ -65,7 +64,6 @@ future changes by simply running `terraform apply
 | provisionaccount_role_description | The description to associate with the IAM role (as well as the corresponding policy) that allows sufficient access to provision all AWS resources in the Shared Services account. | string | `Allows sufficient access to provision all AWS resources in the Shared Services account.` | no |
 | provisionaccount_role_name | The name to assign the IAM role (as well as the corresponding policy) that allows sufficient permissions to provision all AWS resources in the Shared Services account. | string | `ProvisionAccount` | no |
 | tags | Tags to apply to all AWS resources created. | map(string) | `{}` | no |
-| this_account_id | The ID of the account being configured. | string | | yes |
 | users_account_id | The ID of the users account.  This account will be allowed to assume the role that allows sufficient access to provision all AWS resources in the Shared Services account. | string | | yes |
 
 ## Outputs ##

--- a/shared-services/provisionaccount.tf
+++ b/shared-services/provisionaccount.tf
@@ -1,7 +1,6 @@
 module "provisionaccount" {
   source = "../provisionaccount-role-tf-module"
 
-  new_account_id                    = var.this_account_id
   provisionaccount_role_description = var.provisionaccount_role_description
   provisionaccount_role_name        = var.provisionaccount_role_name
   tags                              = var.tags

--- a/shared-services/variables.tf
+++ b/shared-services/variables.tf
@@ -4,10 +4,6 @@
 # You must provide a value for each of these parameters.
 # ------------------------------------------------------------------------------
 
-variable "this_account_id" {
-  description = "The ID of the account being configured."
-}
-
 variable "users_account_id" {
   description = "The ID of the users account.  This account will be allowed to assume the role that allows sufficient permissions to provision all AWS resources in the Shared Services account."
 }

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -64,7 +64,6 @@ To do this, follow these steps:
    variables (see [Inputs](#Inputs) below for details):
 
    ```console
-   this_account_id  = "111111111111"
    users_account_id = "222222222222"
 
    admin_usernames = [
@@ -100,7 +99,6 @@ future changes by simply running `terraform apply
 | state_table_read_capacity | The number of read units for the DynamoDB table that will be used for Terraform state locking. | number | `20` | no |
 | state_table_write_capacity | The number of write units for the DynamoDB table that will be used for Terraform state locking. | number | `20` | no |
 | tags | Tags to apply to all AWS resources created. | map(string) | `{}` | no |
-| this_account_id | The ID of the account being configured. | string | | yes |
 | user_account_id | The ID of the users account.  This account will be allowed to assume the role that allows sufficient access to the Terraform S3 bucket and DynamoDB table to use those resources as a Terraform backend, as well as the role that allows sufficient permissions to provision all AWS resources in the Terraform account. | string | | yes |
 
 ## Outputs ##

--- a/terraform/caller_identity.tf
+++ b/terraform/caller_identity.tf
@@ -1,0 +1,6 @@
+# ------------------------------------------------------------------------------
+# We can get the account ID of the Terraform account from the
+# provider's caller identity.
+# ------------------------------------------------------------------------------
+data "aws_caller_identity" "terraform" {
+}

--- a/terraform/provision_policy.tf
+++ b/terraform/provision_policy.tf
@@ -23,7 +23,7 @@ data "aws_iam_policy_document" "provisionaccount_doc" {
       "dynamodb:*",
     ]
     resources = [
-      "arn:aws:dynamodb:${var.aws_region}:${var.this_account_id}:table/${var.state_table_name}",
+      "arn:aws:dynamodb:${var.aws_region}:${data.aws_caller_identity.terraform.account_id}:table/${var.state_table_name}",
     ]
   }
 }

--- a/terraform/provisionaccount.tf
+++ b/terraform/provisionaccount.tf
@@ -1,7 +1,6 @@
 module "provisionaccount" {
   source = "../provisionaccount-role-tf-module"
 
-  new_account_id                    = var.this_account_id
   provisionaccount_role_description = var.provisionaccount_role_description
   provisionaccount_role_name        = var.provisionaccount_role_name
   tags                              = var.tags

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -8,10 +8,6 @@ variable "state_bucket_name" {
   description = "The name to use for the S3 bucket that will store the Terraform state."
 }
 
-variable "this_account_id" {
-  description = "The ID of the account being configured."
-}
-
 variable "users_account_id" {
   description = "The ID of the users account.  This account will be allowed to assume the role that allows sufficient access to the Terraform S3 bucket and DynamoDB table to use those resources as a Terraform backend, as well as the role that allows sufficient permissions to provision all AWS resources in the Terraform account."
 }

--- a/users/README.md
+++ b/users/README.md
@@ -43,8 +43,6 @@ To do this, follow these steps:
    from the bootstrapping the terraform subdirectory:
 
    ```console
-   this_account_id = "111111111111"
-
    admin_usernames = [
      "user.one",
      "user.two"
@@ -74,7 +72,6 @@ future changes by simply running `terraform apply
 | provisionaccount_role_description | The description to associate with the IAM role that allows access to provision all AWS resources in the Users account | string | `Allows sufficient access to provision all AWS resources in the Users account.` | no |
 | provisionaccount_role_name | The name to assign the IAM role that allows sufficient permissions to provision all AWS resources in the Users account. | string | `ProvisionAccount` | no |
 | tags | Tags to apply to all AWS resources provisioned. | map(string) | `{}` | no |
-| this_account_id | The ID of the account being configured. | string | | yes |
 
 ## Outputs ##
 

--- a/users/caller_identity.tf
+++ b/users/caller_identity.tf
@@ -1,0 +1,6 @@
+# ------------------------------------------------------------------------------
+# We can get the account ID of the Users account from the provider's
+# caller identity.
+# ------------------------------------------------------------------------------
+data "aws_caller_identity" "users" {
+}

--- a/users/provisionaccount.tf
+++ b/users/provisionaccount.tf
@@ -1,9 +1,8 @@
 module "provisionaccount" {
   source = "../provisionaccount-role-tf-module"
 
-  new_account_id                    = var.this_account_id
   provisionaccount_role_description = var.provisionaccount_role_description
   provisionaccount_role_name        = var.provisionaccount_role_name
   tags                              = var.tags
-  users_account_id                  = var.this_account_id
+  users_account_id                  = data.aws_caller_identity.users.account_id
 }

--- a/users/variables.tf
+++ b/users/variables.tf
@@ -9,10 +9,6 @@ variable "godlike_usernames" {
   description = "The usernames associated with the god-like accounts to be created, which are allowed to access the terraform backend, are IAM administrators for the Users account, and are allowed to assume any role that has a trust relationship with the Users account.  The format first.last is recommended.  The keys are the usernames and the values are empty strings (since they are not presently used). Example: { \"firstname1.lastname1\" = \"\",  \"firstname2.lastname2\" = \"\" }"
 }
 
-variable "this_account_id" {
-  description = "The ID of the account being configured."
-}
-
 # ------------------------------------------------------------------------------
 # OPTIONAL PARAMETERS
 #


### PR DESCRIPTION
## 🗣 Description

In this pull request I remove account ID variables as input variables wherever possible.  In some cases these variables were no longer being used, and in others they could be determined from the caller identity of a provider.

## 💭 Motivation and Context

As Thoreau said, "Our life is frittered away by detail. Simplify, simplify."

## 🧪 Testing

I ran `terraform apply` on all these changes and verified that Terraform did not want to change anything.  I also verified that the pre-commit hooks all passed.

## 🚥 Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
