### PR TITLE
Add depends_on clauses where necessary

### DIFF
--- a/images/ami_build_vpc.tf
+++ b/images/ami_build_vpc.tf
@@ -1,5 +1,10 @@
 # The VPC where new AMIs will be built
 resource "aws_vpc" "ami_build" {
+  # We can't perform this action until our policy is in place.
+  depends_on = [
+    aws_iam_role_policy_attachment.provisionvpcs_policy_attachment
+  ]
+
   cidr_block = "192.168.100.0/24"
 
   tags = merge(
@@ -12,10 +17,12 @@ resource "aws_vpc" "ami_build" {
 
 # Public (only) subnet of the AMI build VPC
 resource "aws_subnet" "ami_build_public" {
+  depends_on = [
+    aws_internet_gateway.ami_build
+  ]
+
   cidr_block = "192.168.100.0/24"
   vpc_id     = aws_vpc.ami_build.id
-
-  depends_on = [aws_internet_gateway.ami_build]
 
   tags = merge(
     var.tags,
@@ -72,6 +79,6 @@ resource "aws_network_acl" "ami_build_public" {
   )
 }
 
-# NOTE: No security group is needed for the AMI build instance,
-# since packer creates a temporary security group that only allows inbound
+# NOTE: No security group is needed for the AMI build instance, since
+# packer creates a temporary security group that only allows inbound
 # port 22 and anything outbound.

--- a/terraform/state_bucket.tf
+++ b/terraform/state_bucket.tf
@@ -1,8 +1,13 @@
 # ------------------------------------------------------------------------------
-# Create the S3 bucket where the Terraform state will be stored.
+# Provision the S3 bucket where the Terraform state will be stored.
 # ------------------------------------------------------------------------------
 
 resource "aws_s3_bucket" "state_bucket" {
+  # We can't perform this action until our policy is in place.
+  depends_on = [
+    aws_iam_role_policy_attachment.provisionbackend_policy_attachment,
+  ]
+
   bucket = var.state_bucket_name
   server_side_encryption_configuration {
     rule {

--- a/terraform/state_lock_table.tf
+++ b/terraform/state_lock_table.tf
@@ -4,6 +4,11 @@
 # ------------------------------------------------------------------------------
 
 resource "aws_dynamodb_table" "state_lock_table" {
+  # We can't perform this action until our policy is in place.
+  depends_on = [
+    aws_iam_role_policy_attachment.provisionbackend_policy_attachment,
+  ]
+
   attribute {
     name = "LockID"
     type = "S"


### PR DESCRIPTION
## 🗣 Description

Add `depends_on` clauses to some resources that depend on particular policy attachments.  This should ensure that Terraform provisions/updates the policy before attempting to provision the resources.

## 💭 Motivation and Context

Using the `depends_on` clauses should mean we don't have to run `terraform apply` multiple times to provision our resources.

## 🧪 Testing

I ran a `terraform apply` against the `terraform` subdirectory and verified that no resources were changed.  I couldn't do the same against the `images` subdirectory because it was last run with a newer version of Terraform than what I have.

## 🚥 Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
