### PR TITLE
Output resources, not IDs or ARNs

### DIFF
--- a/audit/README.md
+++ b/audit/README.md
@@ -69,7 +69,7 @@ future changes by simply running `terraform apply
 
 | Name | Description |
 |------|-------------|
-| provisionaccount_role_arn | The ARN of the IAM role that allows sufficient permissions to create all AWS resources in the Audit account. |
+| provisionaccount_role | The IAM role that allows sufficient permissions to create all AWS resources in the Audit account. |
 
 ## Contributing ##
 

--- a/audit/outputs.tf
+++ b/audit/outputs.tf
@@ -1,4 +1,4 @@
-output "provisionaccount_role_arn" {
-  value       = module.provisionaccount.provisionaccount_role_arn
-  description = "The ARN of the IAM role that allows sufficient permissions to provision all AWS resources in the Audit account."
+output "provisionaccount_role" {
+  value       = module.provisionaccount.provisionaccount_role
+  description = "The IAM role that allows sufficient permissions to provision all AWS resources in the Audit account."
 }

--- a/dns/README.md
+++ b/dns/README.md
@@ -69,7 +69,7 @@ future changes by simply running `terraform apply
 
 | Name | Description |
 |------|-------------|
-| provisionaccount_role_arn | The ARN of the IAM role that allows sufficient permissions to create all AWS resources in the DNS account. |
+| provisionaccount_role | The IAM role that allows sufficient permissions to create all AWS resources in the DNS account. |
 
 ## Contributing ##
 

--- a/dns/outputs.tf
+++ b/dns/outputs.tf
@@ -1,4 +1,4 @@
-output "provisionaccount_role_arn" {
-  value       = module.provisionaccount.provisionaccount_role_arn
-  description = "The ARN of the IAM role that allows sufficient permissions to provision all AWS resources in the DNS account."
+output "provisionaccount_role" {
+  value       = module.provisionaccount.provisionaccount_role
+  description = "The IAM role that allows sufficient permissions to provision all AWS resources in the DNS account."
 }

--- a/images/README.md
+++ b/images/README.md
@@ -86,10 +86,10 @@ future changes by simply running `terraform apply
 
 | Name | Description |
 |------|-------------|
-| administerkmskeys_role_arn | The ARN of the IAM role that allows sufficient permissions to administer KMS keys in the Images account. |
-| ami_kms_key_arn | The ARN of the KMS key for encrypting AMIs in the Images account. |
-| ec2amicreate_role_arn | The ARN of the IAM role that allows sufficient permissions to create AMIs in the Images account. |
-| provisionaccount_role_arn | The ARN of the IAM role that allows sufficient permissions to provision all AWS resources in the Images account. |
+| administerkmskeys_role | The IAM role that allows sufficient permissions to administer KMS keys in the Images account. |
+| ami_kms_key | The KMS key for encrypting AMIs in the Images account. |
+| ec2amicreate_role | The IAM role that allows sufficient permissions to create AMIs in the Images account. |
+| provisionaccount_role | The IAM role that allows sufficient permissions to provision all AWS resources in the Images account. |
 
 ## Contributing ##
 

--- a/images/outputs.tf
+++ b/images/outputs.tf
@@ -1,19 +1,19 @@
-output "administerkmskeys_role_arn" {
-  value       = aws_iam_role.administerkmskeys_role.arn
-  description = "The ARN of the IAM role that allows sufficient permissions to administer KMS keys in the Images account."
+output "administerkmskeys_role" {
+  value       = aws_iam_role.administerkmskeys_role
+  description = "The IAM role that allows sufficient permissions to administer KMS keys in the Images account."
 }
 
-output "ami_kms_key_arn" {
-  value       = aws_kms_key.amis.arn
-  description = "The ARN of the KMS key for encrypting AMIs in the Images account."
+output "ami_kms_key" {
+  value       = aws_kms_key.amis
+  description = "The KMS key for encrypting AMIs in the Images account."
 }
 
-output "ec2amicreate_role_arn" {
-  value       = aws_iam_role.ec2amicreate_role.arn
-  description = "The ARN of the IAM role that allows sufficient permissions to create AMIs in the Images account."
+output "ec2amicreate_role" {
+  value       = aws_iam_role.ec2amicreate_role
+  description = "The IAM role that allows sufficient permissions to create AMIs in the Images account."
 }
 
-output "provisionaccount_role_arn" {
-  value       = module.provisionaccount.provisionaccount_role_arn
-  description = "The ARN of the IAM role that allows sufficient permissions to provision all AWS resources in the Images account."
+output "provisionaccount_role" {
+  value       = module.provisionaccount.provisionaccount_role
+  description = "The IAM role that allows sufficient permissions to provision all AWS resources in the Images account."
 }

--- a/log-archive/README.md
+++ b/log-archive/README.md
@@ -70,7 +70,7 @@ future changes by simply running `terraform apply
 
 | Name | Description |
 |------|-------------|
-| provisionaccount_role_arn | The ARN of the IAM role that allows sufficient permissions to create all AWS resources in the Log Archive account. |
+| provisionaccount_role | The IAM role that allows sufficient permissions to create all AWS resources in the Log Archive account. |
 
 ## Contributing ##
 

--- a/log-archive/outputs.tf
+++ b/log-archive/outputs.tf
@@ -1,4 +1,4 @@
-output "provisionaccount_role_arn" {
-  value       = module.provisionaccount.provisionaccount_role_arn
-  description = "The ARN of the IAM role that allows sufficient permissions to provision all AWS resources in the Log Archive account."
+output "provisionaccount_role" {
+  value       = module.provisionaccount.provisionaccount_role
+  description = "The IAM role that allows sufficient permissions to provision all AWS resources in the Log Archive account."
 }

--- a/master/README.md
+++ b/master/README.md
@@ -69,7 +69,7 @@ future changes by simply running `terraform apply
 
 | Name | Description |
 |------|-------------|
-| provisionaccount_role_arn | The ARN of the IAM role that allows sufficient permissions to create all AWS resources in the Master account. |
+| provisionaccount_role | The IAM role that allows sufficient permissions to create all AWS resources in the Master account. |
 
 ## Contributing ##
 

--- a/master/outputs.tf
+++ b/master/outputs.tf
@@ -1,4 +1,4 @@
-output "provisionaccount_role_arn" {
-  value       = module.provisionaccount.provisionaccount_role_arn
-  description = "The ARN of the IAM role that allows sufficient permissions to provision all AWS resources in the Master account."
+output "provisionaccount_role" {
+  value       = module.provisionaccount.provisionaccount_role
+  description = "The IAM role that allows sufficient permissions to provision all AWS resources in the Master account."
 }

--- a/provisionaccount-role-tf-module/README.md
+++ b/provisionaccount-role-tf-module/README.md
@@ -45,8 +45,7 @@ module "provisionaccount" {
 
 | Name | Description |
 |------|-------------|
-| provisionaccount_role_arn | The ARN of the IAM role that allows sufficient permissions to provision all AWS resources in the new account. |
-| provisionaccount_role_name | The name of the IAM role that allows sufficient permissions to provision all AWS resources in the new account. |
+| provisionaccount_role | The IAM role that allows sufficient permissions to provision all AWS resources in the new account. |
 
 ## Contributing ##
 

--- a/provisionaccount-role-tf-module/outputs.tf
+++ b/provisionaccount-role-tf-module/outputs.tf
@@ -1,21 +1,4 @@
-output "provisionaccount_role_arn" {
-  value       = aws_iam_role.provisionaccount_role.arn
-  description = "The ARN of the IAM role that allows sufficient permissions to provision all AWS resources in the new account."
-}
-
-# This value is actually an input variable, but we want to specify it
-# again here.  The reason is simple, if lengthy to explain.
-#
-# Suppose we want to attach another policy to this role, and we have
-# the ARN of this new policy.  The aws_iam_role_policy_attachment
-# Terraform resource requires a policy ARN and a role name.  If we
-# simply use the input variable when defining the
-# aws_iam_role_policy_attachment resource, then the role may not
-# actually exist when Terraform attempts to create the
-# aws_iam_role_policy_attachment resource.  If we use this output
-# instead then the role is guaranteed to exist when Terraform attempts
-# to create the aws_iam_role_policy_attachment resource.
-output "provisionaccount_role_name" {
-  value       = aws_iam_role.provisionaccount_role.name
-  description = "The name of the IAM role that allows sufficient permissions to provision all AWS resources in the new account."
+output "provisionaccount_role" {
+  value       = aws_iam_role.provisionaccount_role
+  description = "The IAM role that allows sufficient permissions to provision all AWS resources in the new account."
 }

--- a/shared-services/README.md
+++ b/shared-services/README.md
@@ -70,7 +70,7 @@ future changes by simply running `terraform apply
 
 | Name | Description |
 |------|-------------|
-| provisionaccount_role_arn | The ARN of the IAM role that allows sufficient permissions to create all AWS resources in the Shared Services account. |
+| provisionaccount_role | The IAM role that allows sufficient permissions to create all AWS resources in the Shared Services account. |
 
 ## Contributing ##
 

--- a/shared-services/outputs.tf
+++ b/shared-services/outputs.tf
@@ -1,4 +1,4 @@
-output "provisionaccount_role_arn" {
-  value       = module.provisionaccount.provisionaccount_role_arn
-  description = "The ARN of the IAM role that allows sufficient permissions to provision all AWS resources in the Shared Services account."
+output "provisionaccount_role" {
+  value       = module.provisionaccount.provisionaccount_role
+  description = "The IAM role that allows sufficient permissions to provision all AWS resources in the Shared Services account."
 }

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -107,12 +107,10 @@ future changes by simply running `terraform apply
 
 | Name | Description |
 |------|-------------|
-| access_terraform_backend_role_arn | The ARN of the IAM role that allows sufficient access to the Terraform S3 bucket and DynamoDB table to use those resources as a Terraform backend. |
-| provisionaccount_role_arn | The ARN of the IAM role that allows sufficient permissions to provision all AWS resources in the Terraform account. |
-| state_bucket_arn | The ARN of the S3 bucket where Terraform state information will be stored. |
-| state_bucket_id | The ID of the S3 bucket where Terraform state information will be stored. |
-| state_lock_table_arn | The ARN of the DynamoDB table that to be used for Terraform state locking. |
-| state_lock_table_id | The ID of the DynamoDB table that to be used for Terraform state locking. |
+| access_terraform_backend_role | The IAM role that allows sufficient access to the Terraform S3 bucket and DynamoDB table to use those resources as a Terraform backend. |
+| provisionaccount_role | The IAM role that allows sufficient permissions to provision all AWS resources in the Terraform account. |
+| state_bucket | The S3 bucket where Terraform state information will be stored. |
+| state_lock_table | The DynamoDB table that to be used for Terraform state locking. |
 
 ## Contributing ##
 

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,29 +1,19 @@
-output "access_terraform_backend_role_arn" {
-  value       = aws_iam_role.access_terraform_backend_role.arn
-  description = "The ARN of the IAM role that allows sufficient access to the Terraform S3 bucket and DynamoDB table to use those resources as a Terraform backend."
+output "access_terraform_backend_role" {
+  value       = aws_iam_role.access_terraform_backend_role
+  description = "The IAM role that allows sufficient access to the Terraform S3 bucket and DynamoDB table to use those resources as a Terraform backend."
 }
 
-output "provisionaccount_role_arn" {
-  value       = module.provisionaccount.provisionaccount_role_arn
-  description = "The ARN of the IAM role that allows sufficient permissions to provision all AWS resources in the Terraform account."
+output "provisionaccount_role" {
+  value       = module.provisionaccount.provisionaccount_role
+  description = "The IAM role that allows sufficient permissions to provision all AWS resources in the Terraform account."
 }
 
-output "state_bucket_arn" {
-  value       = aws_s3_bucket.state_bucket.arn
-  description = "The ARN of the S3 bucket where Terraform state information will be stored."
+output "state_bucket" {
+  value       = aws_s3_bucket.state_bucket
+  description = "The S3 bucket where Terraform state information will be stored."
 }
 
-output "state_bucket_id" {
-  value       = aws_s3_bucket.state_bucket.id
-  description = "The ID of the S3 bucket where Terraform state information will be stored."
-}
-
-output "state_lock_table_arn" {
-  value       = aws_dynamodb_table.state_lock_table.arn
-  description = "The ARN of the DynamoDB table that to be used for Terraform state locking."
-}
-
-output "state_lock_table_id" {
-  value       = aws_dynamodb_table.state_lock_table.id
-  description = "The ID of the DynamoDB table that to be used for Terraform state locking."
+output "state_lock_table" {
+  value       = aws_dynamodb_table.state_lock_table
+  description = "The DynamoDB table that to be used for Terraform state locking."
 }

--- a/terraform/provisionbackend_policy_attachment.tf
+++ b/terraform/provisionbackend_policy_attachment.tf
@@ -5,5 +5,5 @@
 
 resource "aws_iam_role_policy_attachment" "provisionbackend_policy_attachment" {
   policy_arn = aws_iam_policy.provisionbackend_policy.arn
-  role       = module.provisionaccount.provisionaccount_role_name
+  role       = module.provisionaccount.provisionaccount_role.name
 }

--- a/users/README.md
+++ b/users/README.md
@@ -77,10 +77,10 @@ future changes by simply running `terraform apply
 
 | Name | Description |
 |------|-------------|
-| assume_any_role_anywhere_policy_arn | The ARN of the IAM role that allows assumption of any role in any account, so long as it has a trust relationship with the Users account. |
-| godlike_users | A map whose keys are the usernames of, and whose values are the ARNs of, the IAM users that are allowed to access the terraform backend, are IAM administrators for the Users account, and are allowed to assume any role that has a trust relationship with the Users account. |
-| gods_group_arn | The ARN of the IAM group containing the god-like users that are allowed to access the terraform backend, are IAM administrators for the Users account, and are allowed to assume any role that has a trust relationship with the Users account. |
-| provisionaccount_role_arn | The ARN of the IAM role that allows sufficient permissions to provision all AWS resources in this account. |
+| assume_any_role_anywhere_policy | The IAM role that allows assumption of any role in any account, so long as it has a trust relationship with the Users account. |
+| godlike_users | The IAM users that are allowed to access the terraform backend, are IAM administrators for the Users account, and are allowed to assume any role that has a trust relationship with the Users account. |
+| gods_group | The IAM group containing the god-like users that are allowed to access the terraform backend, are IAM administrators for the Users account, and are allowed to assume any role that has a trust relationship with the Users account. |
+| provisionaccount_role | The IAM role that allows sufficient permissions to provision all AWS resources in this account. |
 
 ## Contributing ##
 

--- a/users/outputs.tf
+++ b/users/outputs.tf
@@ -1,19 +1,19 @@
-output "assume_any_role_anywhere_policy_arn" {
-  value       = aws_iam_policy.assume_any_role_anywhere.arn
-  description = "The ARN of the IAM role that allows assumption of any role in any account, so long as it has a trust relationship with the Users account."
+output "assume_any_role_anywhere_policy" {
+  value       = aws_iam_policy.assume_any_role_anywhere
+  description = "The IAM role that allows assumption of any role in any account, so long as it has a trust relationship with the Users account."
 }
 
 output "godlike_users" {
-  value       = { for username, user in aws_iam_user.gods : username => user.arn }
-  description = "A map whose keys are the usernames of, and whose values are the ARNs of, the IAM users that are allowed to access the terraform backend, are IAM administrators for the Users account, and are allowed to assume any role that has a trust relationship with the Users account."
+  value       = aws_iam_user.gods
+  description = "The IAM users that are allowed to access the terraform backend, are IAM administrators for the Users account, and are allowed to assume any role that has a trust relationship with the Users account."
 }
 
-output "gods_group_arn" {
-  value       = aws_iam_group.gods.arn
-  description = "The ARN of the IAM group containing the god-like users that are allowed to access the terraform backend, are IAM administrators for the Users account, and are allowed to assume any role that has a trust relationship with the Users account."
+output "gods_group" {
+  value       = aws_iam_group.gods
+  description = "The IAM group containing the god-like users that are allowed to access the terraform backend, are IAM administrators for the Users account, and are allowed to assume any role that has a trust relationship with the Users account."
 }
 
-output "provisionaccount_role_arn" {
-  value       = module.provisionaccount.provisionaccount_role_arn
-  description = "The ARN of the IAM role that allows sufficient permissions to provision all AWS resources in this account."
+output "provisionaccount_role" {
+  value       = module.provisionaccount.provisionaccount_role
+  description = "The IAM role that allows sufficient permissions to provision all AWS resources in this account."
 }


### PR DESCRIPTION
## 🗣 Description

In this pull request I change all subdirectories to output resources, not IDs or ARNs.

## 💭 Motivation and Context

This is simpler, since all the attributes are already there and hence anyone who uses the outputs does not need to create Terraform data resources to look them up.

## 🧪 Testing

I deployed all these changes to production and verified that Terraform did not want to change anything.  The one case where I could not do this was the `images` subdirectory, since it was last applied by someone with a later version of Terraform than what is currently available to me.

## 🚥 Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
