### PR TITLE
Add AMI launch permissions to key policy for selected accounts

### DIFF
--- a/images/ami_kms_key.tf
+++ b/images/ami_kms_key.tf
@@ -119,9 +119,7 @@ data "aws_iam_policy_document" "ami_kms_doc" {
       values = [
         for account in data.aws_organizations_organization.cool.accounts :
         "arn:aws:iam::${account.id}:role/ProvisionAccount"
-        if length(regexall("^env.*", account.name)) != 0 ||
-        account.name == "Playground Legacy" ||
-        account.name == "Shared Services"
+        if length(regexall("^env|^Playground Legacy$|^Shared Services$", account.name)) > 0
       ]
     }
   }

--- a/images/ami_kms_key.tf
+++ b/images/ami_kms_key.tf
@@ -14,8 +14,10 @@ data "aws_iam_policy_document" "ami_kms_doc" {
     sid = "Enable IAM User Permissions"
 
     principals {
-      type        = "AWS"
-      identifiers = ["arn:aws:iam::${data.aws_caller_identity.images.account_id}:root"]
+      type = "AWS"
+      identifiers = [
+        "arn:aws:iam::${data.aws_caller_identity.images.account_id}:root",
+      ]
     }
 
     actions = [
@@ -32,7 +34,9 @@ data "aws_iam_policy_document" "ami_kms_doc" {
       type = "AWS"
       # This role needs to be created before the key is provisioned,
       # so we can't use aws_iam_role.administerkmskeys_role.arn here.
-      identifiers = ["arn:aws:iam::${data.aws_caller_identity.images.account_id}:role/${var.administerkmskeys_role_name}"]
+      identifiers = [
+        "arn:aws:iam::${data.aws_caller_identity.images.account_id}:role/${var.administerkmskeys_role_name}",
+      ]
     }
 
     actions = [
@@ -58,10 +62,12 @@ data "aws_iam_policy_document" "ami_kms_doc" {
   statement {
     sid = "Allow use of the key"
 
-    # Wildcards (other than the global "*") are not allowed when specifying
-    # a principal (e.g. "${aws_iam_role.ec2amicreate_role.arn}*"), so instead
-    # we set the principal to "*" and restrict access via the condition
-    # below (which does allow for a wildcard pattern match on the role ARN)
+    # Wildcards (other than the global "*") are not allowed when
+    # specifying a principal
+    # (e.g. "${aws_iam_role.ec2amicreate_role.arn}*"), so instead we
+    # set the principal to "*" and restrict access via the condition
+    # below (which does allow for a wildcard pattern match on the role
+    # ARN).
     principals {
       type        = "AWS"
       identifiers = ["*"]

--- a/images/providers.tf
+++ b/images/providers.tf
@@ -9,3 +9,9 @@ provider "aws" {
   # from the AWS SSO page, to bootstrap the account.
   # profile = "cool-images-account-admin"
 }
+
+provider "aws" {
+  alias   = "organizationsreadonly"
+  profile = "cool-master-organizationsreadonly"
+  region  = var.aws_region
+}


### PR DESCRIPTION
## 🗣 Description

In this pull request I add a statement to the key policy that allows selected COOL accounts (the playground, shared services, and env* accounts) sufficient KMS permissions to launch EC2 instances from AMIs encrypted with our KMS key.

## 💭 Motivation and Context

I have to be able to launch such images to deploy FreeIPA and OpenVPN to the Shared Services account.

## 🧪 Testing

I deployed these changes to production and then launched some EC2 instances from AMIs encrypted with the key.

## 🚥 Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
