### PR TITLE
Create variable for AMI build CIDR block

### DIFF
--- a/images/README.md
+++ b/images/README.md
@@ -66,6 +66,7 @@ future changes by simply running `terraform apply
 |------|-------------|:----:|:-------:|:--------:|
 | administerkmskeys_role_description | The description to associate with the IAM role (as well as the corresponding policy) that allows sufficient permissions to administer all KMS keys in the Images account. | string | `Allows sufficient permissions to administer all KMS keys in the Images account.` | no |
 | administerkmskeys_role_name | The name to assign the IAM role (as well as the corresponding policy) that allows sufficient permissions to administer all KMS keys in the Images account. | string | `AdministerKMSKeys` | no |
+| ami_build_cidr | The CIDR block to assign to the VPC and subnet used to build AMIs. | string | `192.168.100.0/24` | no |
 | ami_kms_key_alias | The alias to assign to the KMS key used to encrypt AMIs in the Images account. | string | `cool-amis` | no |
 | ami_kms_key_description | The description to assign to the KMS key used to encrypt AMIs in the Images account. | string | `The key used to encrypt AMIs in this account.` | no |
 | aws_region | The AWS region where the non-global resources for the Images account are to be created (e.g. us-east-1). | string | `us-east-1` | no |

--- a/images/ami_build_vpc.tf
+++ b/images/ami_build_vpc.tf
@@ -5,7 +5,7 @@ resource "aws_vpc" "ami_build" {
     aws_iam_role_policy_attachment.provisionvpcs_policy_attachment
   ]
 
-  cidr_block = "192.168.100.0/24"
+  cidr_block = var.ami_build_cidr
 
   tags = merge(
     var.tags,
@@ -21,7 +21,7 @@ resource "aws_subnet" "ami_build_public" {
     aws_internet_gateway.ami_build
   ]
 
-  cidr_block = "192.168.100.0/24"
+  cidr_block = var.ami_build_cidr
   vpc_id     = aws_vpc.ami_build.id
 
   tags = merge(

--- a/images/variables.tf
+++ b/images/variables.tf
@@ -24,6 +24,11 @@ variable "administerkmskeys_role_name" {
   default     = "AdministerKMSKeys"
 }
 
+variable "ami_build_cidr" {
+  description = "The CIDR block to assign to the VPC and subnet used to build AMIs."
+  default     = "192.168.100.0/24"
+}
+
 variable "ami_kms_key_alias" {
   description = "The alias to assign to the KMS key used to encrypt AMIs in the Images account."
   default     = "cool-amis"


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description
This PR adds a variable (`ami_build_cidr`) to replace the hard-coded CIDR block for the VPC and subnet used to build AMIs.

<!--- Describe your changes in detail -->

## 💭 Motivation and Context
It is an excellent idea, plus it was requested in #26 by @felddy.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing
I did a `terraform plan` in the COOL and verified that no changes were needed as a result of these code changes.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
