### PR TITLE
Specify string type

### DIFF
--- a/audit/variables.tf
+++ b/audit/variables.tf
@@ -5,6 +5,7 @@
 # ------------------------------------------------------------------------------
 
 variable "users_account_id" {
+  type        = string
   description = "The ID of the users account.  This account will be allowed to assume the role that allows sufficient permissions to provision all AWS resources in the Audit account."
 }
 
@@ -15,16 +16,19 @@ variable "users_account_id" {
 # ------------------------------------------------------------------------------
 
 variable "aws_region" {
+  type        = string
   description = "The AWS region where the non-global resources for the Audit account are to be provisioned (e.g. \"us-east-1\")."
   default     = "us-east-1"
 }
 
 variable "provisionaccount_role_description" {
+  type        = string
   description = "The description to associate with the IAM role that allows sufficient permissions to provision all AWS resources in the Audit account."
   default     = "Allows sufficient permissions to provision all AWS resources in the Audit account."
 }
 
 variable "provisionaccount_role_name" {
+  type        = string
   description = "The name to assign the IAM role that allows sufficient permissions to provision all AWS resources in the Audit account."
   default     = "ProvisionAccount"
 }

--- a/dns/variables.tf
+++ b/dns/variables.tf
@@ -5,6 +5,7 @@
 # ------------------------------------------------------------------------------
 
 variable "users_account_id" {
+  type        = string
   description = "The ID of the users account.  This account will be allowed to assume the role that allows sufficient permissions to provision all AWS resources in the DNS account."
 }
 
@@ -15,26 +16,31 @@ variable "users_account_id" {
 # ------------------------------------------------------------------------------
 
 variable "aws_region" {
+  type        = string
   description = "The AWS region where the non-global resources for the DNS account are to be provisioned (e.g. \"us-east-1\")."
   default     = "us-east-1"
 }
 
 variable "provisionaccount_role_description" {
+  type        = string
   description = "The description to associate with the IAM role that allows sufficient permissions to provision all AWS resources in the DNS account."
   default     = "Allows sufficient permissions to provision all AWS resources in the DNS account."
 }
 
 variable "provisionaccount_role_name" {
+  type        = string
   description = "The name to assign the IAM role that allows sufficient permissions to provision all AWS resources in the DNS account."
   default     = "ProvisionAccount"
 }
 
 variable "provisionroute53_role_description" {
+  type        = string
   description = "The description to associate with the IAM role (as well as the corresponding policy) that allows sufficient permissions to provision Route 53 in the DNS account."
   default     = "Allows sufficient permissions to provision Route 53 in the DNS account."
 }
 
 variable "provisionroute53_role_name" {
+  type        = string
   description = "The name to assign the IAM role (as well as the corresponding policy) that allows sufficient permissions to provision Route 53 in the DNS account."
   default     = "ProvisionRoute53"
 }

--- a/dynamic/variables.tf
+++ b/dynamic/variables.tf
@@ -5,10 +5,12 @@
 # ------------------------------------------------------------------------------
 
 variable "dynamic_account_name" {
+  type        = string
   description = "The name of the dynamic account to be provisioned."
 }
 
 variable "users_account_id" {
+  type        = string
   description = "The ID of the users account.  This account will be allowed to assume the role that allows sufficient permissions to provision all AWS resources in the dynamic account."
 }
 
@@ -19,16 +21,19 @@ variable "users_account_id" {
 # ------------------------------------------------------------------------------
 
 variable "aws_region" {
+  type        = string
   description = "The AWS region where the non-global resources for the dynamic account are to be provisioned (e.g. \"us-east-1\")."
   default     = "us-east-1"
 }
 
 variable "provisionaccount_role_description" {
+  type        = string
   description = "The description to associate with the IAM role that allows sufficient permissions to provision all AWS resources in the dynamic account."
   default     = "Allows sufficient permissions to provision all AWS resources in the dynamic account."
 }
 
 variable "provisionaccount_role_name" {
+  type        = string
   description = "The name to assign the IAM role that allows sufficient permissions to provision all AWS resources in the dynamic account."
   default     = "ProvisionAccount"
 }

--- a/images/variables.tf
+++ b/images/variables.tf
@@ -5,6 +5,7 @@
 # ------------------------------------------------------------------------------
 
 variable "users_account_id" {
+  type        = string
   description = "The ID of the users account.  This account will be allowed to assume the role that allows sufficient permissions to provision all AWS resources in the Images account."
 }
 
@@ -15,81 +16,97 @@ variable "users_account_id" {
 # ------------------------------------------------------------------------------
 
 variable "administerkmskeys_role_description" {
+  type        = string
   description = "The description to associate with the IAM role (as well as the corresponding policy) that allows sufficient permissions to administer all KMS keys in the Images account."
   default     = "Allows sufficient permissions to administer all KMS keys in the Images account."
 }
 
 variable "administerkmskeys_role_name" {
+  type        = string
   description = "The name to assign the IAM role (as well as the corresponding policy) that allows sufficient permissions to administer all KMS keys in the Images account."
   default     = "AdministerKMSKeys"
 }
 
 variable "ami_build_cidr" {
+  type        = string
   description = "The CIDR block to assign to the VPC and subnet used to build AMIs."
   default     = "192.168.100.0/24"
 }
 
 variable "ami_kms_key_alias" {
+  type        = string
   description = "The alias to assign to the KMS key used to encrypt AMIs in the Images account."
   default     = "cool-amis"
 }
 
 variable "ami_kms_key_description" {
+  type        = string
   description = "The description to assign to the KMS key used to encrypt AMIs in the Images account."
   default     = "The key used to encrypt AMIs in this account."
 }
 
 variable "aws_region" {
+  type        = string
   description = "The AWS region where the non-global resources for the Images account are to be provisioned (e.g. \"us-east-1\")."
   default     = "us-east-1"
 }
 
 variable "ec2amicreate_role_description" {
+  type        = string
   description = "The description to associate with the IAM role (as well as the corresponding policy) that allows sufficient permissions to create AMIs in the Images account."
   default     = "Allows sufficient permissions to create AMIs in the Images account."
 }
 
 variable "ec2amicreate_role_name" {
+  type        = string
   description = "The name to assign the IAM role (as well as the corresponding policy) that allows sufficient permissions to create AMIs in the Images account."
   default     = "EC2AMICreate"
 }
 
 variable "provisionaccount_role_description" {
+  type        = string
   description = "The description to associate with the IAM role that allows sufficient permissions to provision all AWS resources in the Images account."
   default     = "Allows sufficient permissions to provision all AWS resources in the Images account."
 }
 
 variable "provisionaccount_role_name" {
+  type        = string
   description = "The name to assign the IAM role that allows sufficient permissions to provision all AWS resources in the Images account."
   default     = "ProvisionAccount"
 }
 
 variable "provisionec2amicreateroles_role_description" {
+  type        = string
   description = "The description to associate with the IAM role (as well as the corresponding policy) with the ability to create IAM roles that can create AMIs in the Images account."
   default     = "Allows creation of IAM roles that can create AMIs in the Images account."
 }
 
 variable "provisionec2amicreateroles_role_name" {
+  type        = string
   description = "The name to assign the IAM role (as well as the corresponding policy) with the ability to create IAM roles that can create AMIs in the Images account."
   default     = "ProvisionEC2AMICreateRoles"
 }
 
 variable "provisionkmskeys_role_description" {
+  type        = string
   description = "The description to associate with the IAM role (as well as the corresponding policy) that allows sufficient permissions to provision KMS keys in the Images account."
   default     = "Allows sufficient permissions to provision KMS keys in the Images account."
 }
 
 variable "provisionkmskeys_role_name" {
+  type        = string
   description = "The name to assign the IAM role (as well as the corresponding policy) that allows sufficient permissions to provision KMS keys in the Images account."
   default     = "ProvisionKMSKeys"
 }
 
 variable "provisionvpcs_policy_description" {
+  type        = string
   description = "The description to associate with the IAM policy that allows sufficient permissions to provision VPCs (and related resources) in the Images account."
   default     = "Allows sufficient permissions to provision VPCs (and related resources) in the Images account."
 }
 
 variable "provisionvpcs_policy_name" {
+  type        = string
   description = "The name to assign the IAM policy that allows sufficient permissions to provision VPCs (and related resources) in the Images account."
   default     = "ProvisionVPCs"
 }

--- a/log-archive/variables.tf
+++ b/log-archive/variables.tf
@@ -5,6 +5,7 @@
 # ------------------------------------------------------------------------------
 
 variable "users_account_id" {
+  type        = string
   description = "The ID of the users account.  This account will be allowed to assume the role that allows sufficient permissions to provision all AWS resources in the Log Archive account."
 }
 
@@ -15,16 +16,19 @@ variable "users_account_id" {
 # ------------------------------------------------------------------------------
 
 variable "aws_region" {
+  type        = string
   description = "The AWS region where the non-global resources for the Log Archive account are to be provisioned (e.g. \"us-east-1\")."
   default     = "us-east-1"
 }
 
 variable "provisionaccount_role_description" {
+  type        = string
   description = "The description to associate with the IAM role that allows sufficient permissions to provision all AWS resources in the Log Archive account."
   default     = "Allows sufficient permissions to provision all AWS resources in the Log Archive account."
 }
 
 variable "provisionaccount_role_name" {
+  type        = string
   description = "The name to assign the IAM role that allows sufficient permissions to provision all AWS resources in the Log Archive account."
   default     = "ProvisionAccount"
 }

--- a/master/variables.tf
+++ b/master/variables.tf
@@ -5,6 +5,7 @@
 # ------------------------------------------------------------------------------
 
 variable "users_account_id" {
+  type        = string
   description = "The ID of the users account.  This account will be allowed to assume the role that allows sufficient permissions to provision all AWS resources in the Master account."
 }
 
@@ -15,26 +16,31 @@ variable "users_account_id" {
 # ------------------------------------------------------------------------------
 
 variable "aws_region" {
+  type        = string
   description = "The AWS region where the non-global resources for the Master account are to be provisioned (e.g. \"us-east-1\")."
   default     = "us-east-1"
 }
 
 variable "organizationsreadonly_role_description" {
+  type        = string
   description = "The description to associate with the IAM role that allows read-only access to all AWS Organizations information in the Master account."
   default     = "Allows read-only access to all AWS Organizations information in the Master account."
 }
 
 variable "organizationsreadonly_role_name" {
+  type        = string
   description = "The name to assign the IAM role that allows read-only access to all AWS Organizations information in the Master account."
   default     = "OrganizationsReadOnly"
 }
 
 variable "provisionaccount_role_description" {
+  type        = string
   description = "The description to associate with the IAM role that allows sufficient permissions to provision all AWS resources in the Master account."
   default     = "Allows sufficient permissions to provision all AWS resources in the Master account."
 }
 
 variable "provisionaccount_role_name" {
+  type        = string
   description = "The name to assign the IAM role that allows sufficient permissions to provision all AWS resources in the Master account."
   default     = "ProvisionAccount"
 }

--- a/provisionaccount-role-tf-module/examples/basic_usage/variables.tf
+++ b/provisionaccount-role-tf-module/examples/basic_usage/variables.tf
@@ -5,10 +5,12 @@
 # ------------------------------------------------------------------------------
 
 variable "this_account_id" {
+  type        = string
   description = "The ID of the account being configured."
 }
 
 variable "users_account_id" {
+  type        = string
   description = "The ID of the users account.  This account will be allowed to assume the role that allows sufficient permissions to provision all AWS resources in the Pettifogger0 account."
 }
 
@@ -19,16 +21,19 @@ variable "users_account_id" {
 # ------------------------------------------------------------------------------
 
 variable "aws_region" {
+  type        = string
   description = "The AWS region where the non-global resources for the Pettifogger0 account are to be provisioned (e.g. \"us-east-1\")."
   default     = "us-east-1"
 }
 
 variable "provisionaccount_role_description" {
+  type        = string
   description = "The description to associate with the IAM role that allows sufficient permissions to provision all AWS resources in the Pettifogger0 account."
   default     = "Allows sufficient permissions to provision all AWS resources in the Pettifogger0 account."
 }
 
 variable "provisionaccount_role_name" {
+  type        = string
   description = "The name to assign the IAM role that allows sufficient permissions to provision all AWS resources in the Pettifogger0 account."
   default     = "ProvisionAccount"
 }

--- a/provisionaccount-role-tf-module/variables.tf
+++ b/provisionaccount-role-tf-module/variables.tf
@@ -5,14 +5,17 @@
 # ------------------------------------------------------------------------------
 
 variable "provisionaccount_role_description" {
+  type        = string
   description = "The description to associate with the IAM role that allows sufficient permissions to provision all AWS resources in the new account (e.g. \"Allows sufficient permissions to provision all AWS resources in the DNS account.\")."
 }
 
 variable "provisionaccount_role_name" {
+  type        = string
   description = "The name to assign the IAM role that allows sufficient permissions to provision all AWS resources in the new account (e.g. \"ProvisionAccount\")."
 }
 
 variable "users_account_id" {
+  type        = string
   description = "The ID of the users account.  This account will be allowed to assume the role that allows sufficient permissions to provision all AWS resources in the new account."
 }
 
@@ -23,6 +26,7 @@ variable "users_account_id" {
 # ------------------------------------------------------------------------------
 
 variable "aws_region" {
+  type        = string
   description = "The AWS region where the non-global resources for the new account are to be provisioned (e.g. \"us-east-1\")."
   default     = "us-east-1"
 }

--- a/shared-services/variables.tf
+++ b/shared-services/variables.tf
@@ -5,6 +5,7 @@
 # ------------------------------------------------------------------------------
 
 variable "users_account_id" {
+  type        = string
   description = "The ID of the users account.  This account will be allowed to assume the role that allows sufficient permissions to provision all AWS resources in the Shared Services account."
 }
 
@@ -15,16 +16,19 @@ variable "users_account_id" {
 # ------------------------------------------------------------------------------
 
 variable "aws_region" {
+  type        = string
   description = "The AWS region where the non-global resources for the Shared Services account are to be provisioned (e.g. \"us-east-1\")."
   default     = "us-east-1"
 }
 
 variable "provisionaccount_role_description" {
+  type        = string
   description = "The description to associate with the IAM role that allows sufficient permissions to provision all AWS resources in the Shared Services account."
   default     = "Allows sufficient permissions to provision all AWS resources in the Shared Services account."
 }
 
 variable "provisionaccount_role_name" {
+  type        = string
   description = "The name to assign the IAM role that allows sufficient permissions to provision all AWS resources in the Shared Services account."
   default     = "ProvisionAccount"
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -5,10 +5,12 @@
 # ------------------------------------------------------------------------------
 
 variable "state_bucket_name" {
+  type        = string
   description = "The name to use for the S3 bucket that will store the Terraform state."
 }
 
 variable "users_account_id" {
+  type        = string
   description = "The ID of the users account.  This account will be allowed to assume the role that allows sufficient access to the Terraform S3 bucket and DynamoDB table to use those resources as a Terraform backend, as well as the role that allows sufficient permissions to provision all AWS resources in the Terraform account."
 }
 
@@ -19,41 +21,49 @@ variable "users_account_id" {
 # ------------------------------------------------------------------------------
 
 variable "access_terraform_backend_role_description" {
+  type        = string
   description = "The description to associate with the IAM role (as well as the corresponding policy) that allows sufficient access to the Terraform S3 bucket and DynamoDB table to use those resources as a Terraform backend."
   default     = "Allows sufficient access to the Terraform S3 bucket and DynamoDB table to use those resources as a Terraform backend."
 }
 
 variable "access_terraform_backend_role_name" {
+  type        = string
   description = "The name to assign the IAM role (as well as the corresponding policy) that allows sufficient access to the Terraform S3 bucket and DynamoDB table to use those resources as a Terraform backend."
   default     = "AccessTerraformBackend"
 }
 
 variable "aws_region" {
+  type        = string
   description = "The AWS region where the non-global resources for this account are to be provisioned (e.g. \"us-east-1\")."
   default     = "us-east-1"
 }
 
 variable "provisionaccount_role_description" {
+  type        = string
   description = "The description to associate with the IAM role that allows sufficient permissions to provision all AWS resources in the Terraform account."
   default     = "Allows sufficient permissions to provision all AWS resources in the Terraform account."
 }
 
 variable "provisionaccount_role_name" {
+  type        = string
   description = "The name to assign the IAM role that allows sufficient permissions to provision all AWS resources in the Terraform account."
   default     = "ProvisionAccount"
 }
 
 variable "provisionbackend_policy_description" {
+  type        = string
   description = "The description to associate with the IAM policy that allows sufficient permissions to provision the Terraform backend resources in the Terraform account."
   default     = "Allows sufficient permissions to provision the Terraform backend resources in the Terraform account."
 }
 
 variable "provisionbackend_policy_name" {
+  type        = string
   description = "The name to assign the IAM policy that allows sufficient permissions to provision the Terraform backend resources in the Terraform account."
   default     = "ProvisionBackend"
 }
 
 variable "state_table_name" {
+  type        = string
   description = "The name to use for the DynamoDB table that will be used for Terraform state locking."
   default     = "terraform-state-lock"
 }

--- a/users/variables.tf
+++ b/users/variables.tf
@@ -16,31 +16,37 @@ variable "godlike_usernames" {
 # ------------------------------------------------------------------------------
 
 variable "assume_any_role_anywhere_policy_description" {
+  type        = string
   description = "The description to associate with the IAM policy that allows assumption of any role in any account, so long as it has a trust relationship with the Users account."
   default     = "Allow assumption of any role in any account, so long as it has a trust relationship with the Users account."
 }
 
 variable "assume_any_role_anywhere_policy_name" {
+  type        = string
   description = "The name to assign the IAM policy that allows assumption of any role in any account, so long as it has a trust relationship with the Users account."
   default     = "AssumeAnyRoleAnywhere"
 }
 
 variable "aws_region" {
+  type        = string
   description = "The AWS region where the non-global resources for this account are to be provisioned (e.g. \"us-east-1\")."
   default     = "us-east-1"
 }
 
 variable "gods_group_name" {
+  type        = string
   description = "The name of the group to be created for the god-like users that are allowed to access the terraform backend, are IAM administrators for the Users account, and are allowed to assume any role that has a trust relationship with the Users account."
   default     = "gods"
 }
 
 variable "provisionaccount_role_description" {
+  type        = string
   description = "The description to associate with the IAM role that allows access to provision all AWS resources in the Users account."
   default     = "Allows sufficient access to provision all AWS resources in the Users account."
 }
 
 variable "provisionaccount_role_name" {
+  type        = string
   description = "The name to assign the IAM role that allows sufficient permissions to provision all AWS resources in the Users account."
   default     = "ProvisionAccount"
 }


### PR DESCRIPTION
## 🗣 Description

Previously string was the default type, but this is [no longer the case](https://www.terraform.io/docs/configuration/variables.html#type-constraints).

I ran into a case today where this mattered.  I used `set([var.string_value])` in a `for_each`, and Terraform rejected the syntax since it couldn't verify that the output would be a set of strings.  Adding the string type declaration to the variable fixed the issue.

## 💭 Motivation and Context

This change makes the code more correct, and it will avoid subtle errors like the one I saw today.

## 🧪 Testing

I ran a `terraform apply` and verified that nothing needed to be changed.

## 🚥 Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
