### PR TITLE
Use a single key for the backend (dynamic subdirectory)

### DIFF
--- a/dynamic/backend.tf
+++ b/dynamic/backend.tf
@@ -5,9 +5,6 @@ terraform {
     dynamodb_table = "terraform-state-lock"
     profile        = "cool-terraform-backend"
     region         = "us-east-1"
-    # Locally change DYNAMIC_ACCOUNT_NAME below
-    # to the name of the new environment
-    # TODO: https://github.com/cisagov/cool-accounts/issues/34
-    key = "cool-accounts/DYNAMIC_ACCOUNT_NAME.tfstate"
+    key            = "cool-accounts/dynamic.tfstate"
   }
 }


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description
This PR changes the Terraform backend key from a dynamic value that changes depending on the environment being provisioned (e.g. `cool-accounts/env0.tfstate`) to a static value that can be used with every environment (`cool-accounts/dynamic.tfstate`).

Closes #34, since the script described in that issue is no longer needed.

<!--- Describe your changes in detail -->

## 💭 Motivation and Context
During the process of bootstrapping `env1`, I realized the error of my earlier ways.  By simply using a different Terraform workspace for each dynamic environment, each environment's resources will be separated and there is no need to have a different backend key for each one.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing
After modifying the backend key, I successfully re-initialized the `env0` workspace.  Then I created a new Terraform workspace for `env1`, initialized it, and applied it successfully.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
