### PR TITLE
Make AMI KMS key usable by accounts of the same type (Production, Staging)

### DIFF
--- a/images/ami_kms_key.tf
+++ b/images/ami_kms_key.tf
@@ -119,7 +119,7 @@ data "aws_iam_policy_document" "ami_kms_doc" {
       values = [
         for account in data.aws_organizations_organization.cool.accounts :
         "arn:aws:iam::${account.id}:role/ProvisionAccount"
-        if length(regexall("^env.*\\(${local.this_account_type}\\)$|^Playground Legacy \\(${local.this_account_type}\\)$|^Shared Services \\(${local.this_account_type}\\)$", account.name)) > 0
+        if length(regexall("^env[0-9]* \\(${local.this_account_type}\\)$|^Playground Legacy \\(${local.this_account_type}\\)$|^Shared Services \\(${local.this_account_type}\\)$", account.name)) > 0
       ]
     }
   }

--- a/images/ami_kms_key.tf
+++ b/images/ami_kms_key.tf
@@ -119,7 +119,7 @@ data "aws_iam_policy_document" "ami_kms_doc" {
       values = [
         for account in data.aws_organizations_organization.cool.accounts :
         "arn:aws:iam::${account.id}:role/ProvisionAccount"
-        if length(regexall("^env|^Playground Legacy$|^Shared Services$", account.name)) > 0
+        if length(regexall("^env.*\\(${local.this_account_type}\\)$|^Playground Legacy \\(${local.this_account_type}\\)$|^Shared Services \\(${local.this_account_type}\\)$", account.name)) > 0
       ]
     }
   }

--- a/images/locals.tf
+++ b/images/locals.tf
@@ -18,5 +18,5 @@ locals {
   # Determine Images account type based on AWS account name
   # Account name format:  "ACCOUNT_NAME (ACCOUNT_TYPE)"
   #         For example:  "Images (Production)"
-  this_account_type = length(regexall("\\((.*?)\\)", local.this_account_name)) == 1 ? regex("\\((.*?)\\)", local.this_account_name)[0] : "Unknown"
+  this_account_type = length(regexall("\\(([^()]*)\\)", local.this_account_name)) == 1 ? regex("\\(([^()]*)\\)", local.this_account_name)[0] : "Unknown"
 }

--- a/images/locals.tf
+++ b/images/locals.tf
@@ -4,4 +4,19 @@ locals {
     "tcp",
     "udp",
   ]
+
+  # Get current Images account ID from Images provider
+  this_account_id = data.aws_caller_identity.images.account_id
+
+  # Look up current Images account name from AWS organizations provider
+  this_account_name = [
+    for account in data.aws_organizations_organization.cool.accounts :
+    account.name
+    if account.id == local.this_account_id
+  ][0]
+
+  # Determine Images account type based on AWS account name
+  # Account name format:  "ACCOUNT_NAME (ACCOUNT_TYPE)"
+  #         For example:  "Images (Production)"
+  this_account_type = length(regexall("\\((.*?)\\)", local.this_account_name)) == 1 ? regex("\\((.*?)\\)", local.this_account_name)[0] : "Unknown"
 }


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description
This PR modifies the policy for the AMI KMS key so that it allows the key to be used by accounts of the same type as the calling account, such that a:

- Key created in `Images (Production)` account is allowed to be used by:
  - `env.* (Production)`
  - `Playground Legacy (Production)`
  - `Shared Services (Production)`

- Key created in `Images (Staging)` account is allowed to be used by:
  - `env.* (Staging)`
  - `Playground Legacy (Staging)`
  - `Shared Services (Staging)`

Resolves #41.
<!--- Describe your changes in detail -->

## 💭 Motivation and Context

When this code was first written, there was only one type of environment. Now that we have multiple environment types (`Production`, `Staging`), we need to update this code accordingly. 

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing
The updated Terraform was successfully applied in both the `staging` and `production` workspaces.  Before applying in each workspace, I confirmed that the correct accounts (Staging vs. Production) were going to be included in the updated key policy.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
