### PR TITLE
Terraform role and policy updates

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -96,6 +96,8 @@ future changes by simply running `terraform apply
 | provisionaccount_role_name | The name to assign the IAM role that allows sufficient permissions to provision all AWS resources in the terraform account. | string | `ProvisionAccount` | no |
 | provisionbackend_policy_description | The description to associate with the IAM policy that allows sufficient access to provision the Terraform backend resources in the Terraform account. | string | `Allows sufficient access to provision the Terraform backend resources in the Terraform account.` | no |
 | provisionbackend_policy_name | The name to assign the IAM policy that allows sufficient permissions to provision the Terraform backend resources in the terraform account. | string | `ProvisionBackend` | no |
+| read_terraform_state_role_description | The description to associate with the IAM role (as well as the corresponding policy) that allows read-only access to the S3 bucket where Terraform state is stored. | string | `Allows read-only access to the S3 bucket where Terraform state is stored.` | no |
+| read_terraform_state_role_name | The name to assign the IAM role (as well as the corresponding policy) that allows read-only access to the S3 bucket where Terraform state is stored. | string | `ReadTerraformState` | no |
 | state_bucket_name | The name to use for the S3 bucket that will store the Terraform state. | string | | yes |
 | state_table_name | The name to use for the DynamoDB table that will be used for Terraform state locking. | string | `terraform-state-lock` | no |
 | state_table_read_capacity | The number of read units for the DynamoDB table that will be used for Terraform state locking. | number | `20` | no |

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -111,6 +111,7 @@ future changes by simply running `terraform apply
 |------|-------------|
 | access_terraform_backend_role | The IAM role that allows sufficient access to the Terraform S3 bucket and DynamoDB table to use those resources as a Terraform backend. |
 | provisionaccount_role | The IAM role that allows sufficient permissions to provision all AWS resources in the Terraform account. |
+| read_terraform_state_role | The IAM role that allows read-only access to the S3 bucket where Terraform state is stored. |
 | state_bucket | The S3 bucket where Terraform state information will be stored. |
 | state_lock_table | The DynamoDB table that to be used for Terraform state locking. |
 

--- a/terraform/accessbackend_policy.tf
+++ b/terraform/accessbackend_policy.tf
@@ -18,6 +18,7 @@ data "aws_iam_policy_document" "access_terraform_backend_access_doc" {
 
   statement {
     actions = [
+      "s3:DeleteObject",
       "s3:GetObject",
       "s3:PutObject",
     ]

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -8,6 +8,11 @@ output "provisionaccount_role" {
   description = "The IAM role that allows sufficient permissions to provision all AWS resources in the Terraform account."
 }
 
+output "read_terraform_state_role" {
+  value       = aws_iam_role.read_terraform_state_role
+  description = "The IAM role that allows read-only access to the S3 bucket where Terraform state is stored."
+}
+
 output "state_bucket" {
   value       = aws_s3_bucket.state_bucket
   description = "The S3 bucket where Terraform state information will be stored."

--- a/terraform/readstate_policy.tf
+++ b/terraform/readstate_policy.tf
@@ -1,0 +1,34 @@
+# ------------------------------------------------------------------------------
+# Create the IAM policy that allows read-only access to the S3 bucket
+# where Terraform remote state is stored.  This is useful for cases when
+# the remote state data is needed, but full access to the backend is not.
+# ------------------------------------------------------------------------------
+
+# IAM policy document that allows read-only access to the
+# Terraform state bucket.
+data "aws_iam_policy_document" "read_terraform_state_doc" {
+  statement {
+    actions = [
+      "s3:ListBucket",
+    ]
+    resources = [
+      aws_s3_bucket.state_bucket.arn,
+    ]
+  }
+
+  statement {
+    actions = [
+      "s3:GetObject",
+    ]
+    resources = [
+      "${aws_s3_bucket.state_bucket.arn}/*",
+    ]
+  }
+}
+
+# The IAM policy
+resource "aws_iam_policy" "read_terraform_state_policy" {
+  description = var.read_terraform_state_role_description
+  name        = var.read_terraform_state_role_name
+  policy      = data.aws_iam_policy_document.read_terraform_state_doc.json
+}

--- a/terraform/readstate_role.tf
+++ b/terraform/readstate_role.tf
@@ -1,0 +1,18 @@
+# ------------------------------------------------------------------------------
+# Create the IAM role that allows read-only access to the S3 bucket
+# where Terraform remote state is stored.  This is useful for cases when
+# the remote state data is needed, but full access to the backend is not.
+# ------------------------------------------------------------------------------
+
+resource "aws_iam_role" "read_terraform_state_role" {
+  assume_role_policy = data.aws_iam_policy_document.assume_role_doc.json
+  description        = var.read_terraform_state_role_description
+  name               = var.read_terraform_state_role_name
+  tags               = var.tags
+}
+
+# Attach the IAM policy to the role
+resource "aws_iam_role_policy_attachment" "read_terraform_state_policy_attachment" {
+  policy_arn = aws_iam_policy.read_terraform_state_policy.arn
+  role       = aws_iam_role.read_terraform_state_role.name
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -62,6 +62,18 @@ variable "provisionbackend_policy_name" {
   default     = "ProvisionBackend"
 }
 
+variable "read_terraform_state_role_description" {
+  type        = string
+  description = "The description to associate with the IAM role (as well as the corresponding policy) that allows read-only access to the S3 bucket where Terraform state is stored."
+  default     = "Allows read-only access to the S3 bucket where Terraform state is stored."
+}
+
+variable "read_terraform_state_role_name" {
+  type        = string
+  description = "The name to assign the IAM role (as well as the corresponding policy) that allows read-only access to the S3 bucket where Terraform state is stored."
+  default     = "ReadTerraformState"
+}
+
 variable "state_table_name" {
   type        = string
   description = "The name to use for the DynamoDB table that will be used for Terraform state locking."


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description
This PR does two things:

1. Allows the `AccessTerraformBackend` role to delete objects from the S3 bucket where Terraform state is stored.
1. Creates a new role and policy that allows read-only access to the S3 bucket where Terraform state is stored.

Resolves #43.

<!--- Describe your changes in detail -->

## 💭 Motivation and Context

Item (1) above allows us to delete Terraform workspaces from the command line.
Item (2) above gives us a role that can be used when we only need read-only access to the Terraform state, for example when setting up `terraform_remote_state` access.  

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing
This Terraform was successfully applied in production.

- I verified that I was able to delete Terraform workspaces from the command line.
- I verified that the new `ReadTerraformState` role had sufficient access to read remote state data by making local changes to [this line](https://github.com/cisagov/pca-teamserver-aws/blob/develop/terraform/remote_state.tf#L13) and doing a `terraform plan`.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
