### PR TITLE
Add SSM Session Manager role

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,4 @@
 # the repo. Unless a later match takes precedence,
 # these owners will be requested for review when someone
 # opens a pull request.
-*       @dav3r @felddy @jsf9k @mcdonnnj @cisagov/team-ois
+*       @dav3r @felddy @hillaryj @jsf9k @mcdonnnj @cisagov/team-ois

--- a/.github/lineage.yml
+++ b/.github/lineage.yml
@@ -1,0 +1,6 @@
+---
+version: "1"
+
+lineage:
+  skeleton:
+    remote-url: https://github.com/cisagov/skeleton-tf-module.git

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,11 @@
 ---
 name: build
 
-on: [
-  push,
-  pull_request
-]
+on:
+  push:
+  pull_request:
+  repository_dispatch:
+    types: [apb]
 
 env:
   CURL_CACHE_DIR: ~/.cache/curl
@@ -21,9 +22,9 @@ jobs:
       - uses: actions/setup-python@v1
         with:
           python-version: 3.8
-      - uses: actions/setup-go@v2-beta
+      - uses: actions/setup-go@v2
         with:
-          go-version: '1.13.8'
+          go-version: '1.14.2'
       - name: Store installed Python version
         run: |
           echo "::set-env name=PY_VERSION::"\
@@ -71,11 +72,20 @@ jobs:
             ${{ env.CURL_CACHE_DIR }}/"${TERRAFORM_ZIP}"
           sudo ln -s /opt/terraform/terraform /usr/bin/terraform
       - name: Install Terraform-docs
-        run: go get github.com/segmentio/terraform-docs
+        run: GO111MODULE=on go get github.com/segmentio/terraform-docs
+      - name: Find and initialize Terraform directories
+        run: |
+          for path in $(find . -type f -iname "*.tf" -exec dirname "{}" \; \
+            | sort -u); do \
+            echo "Initializing '$path'..."; \
+            terraform init -upgrade=true -input=false -backend=false "$path"; \
+            done
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install --upgrade --requirement requirements-test.txt
+      - name: Set up pre-commit hook environments
+        run: pre-commit install-hooks
       - name: Run pre-commit on all files
         run: pre-commit run --all-files
       - name: Setup tmate debug session

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 .mypy_cache
-__pycache__
 .python-version
 .terraform
 *.tfvars
+__pycache__
 terraform.tfstate
 terraform.tfstate.backup

--- a/.mdl_config.json
+++ b/.mdl_config.json
@@ -3,5 +3,8 @@
     "code_blocks": false,
     "tables": false
   },
+  "MD024": {
+    "allow_different_nesting": true
+  },
   "default": true
 }

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,13 +27,13 @@ repos:
       - id: requirements-txt-fixer
       - id: trailing-whitespace
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.22.0
+    rev: v0.23.0
     hooks:
       - id: markdownlint
         args:
           - --config=.mdl_config.json
   - repo: https://github.com/adrienverge/yamllint
-    rev: v1.20.0
+    rev: v1.23.0
     hooks:
       - id: yamllint
   - repo: https://github.com/detailyang/pre-commit-shell
@@ -41,13 +41,13 @@ repos:
     hooks:
       - id: shell-lint
   - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.7.9
+    rev: 3.8.1
     hooks:
       - id: flake8
         additional_dependencies:
           - flake8-docstrings
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.0.0
+    rev: v2.4.1
     hooks:
       - id: pyupgrade
   - repo: https://github.com/PyCQA/bandit
@@ -61,34 +61,47 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/asottile/seed-isort-config
-    rev: v1.9.4
+    rev: v2.1.1
     hooks:
       - id: seed-isort-config
-  - repo: https://github.com/pre-commit/mirrors-isort
-    # pick the isort version you'd like to use from
-    # https://github.com/pre-commit/mirrors-isort/releases
-    rev: v4.3.21
+  - repo: https://github.com/timothycrosley/isort
+    rev: 4.3.21
     hooks:
       - id: isort
   - repo: https://github.com/ansible/ansible-lint.git
-    rev: v4.2.0
+    rev: v4.3.0a0
     hooks:
       - id: ansible-lint
       # files: molecule/default/playbook.yml
   - repo: https://github.com/antonbabenko/pre-commit-terraform.git
-    rev: v1.12.0
+    rev: v1.30.0
     hooks:
       - id: terraform_fmt
-      - id: terraform_validate_no_variables
+      # There are ongoing issues with how this command works. This issue
+      # documents the core issue:
+      # https://github.com/hashicorp/terraform/issues/21408
+      # We have seen issues primarily with proxy providers and Terraform code
+      # that uses remote state. The PR
+      # https://github.com/hashicorp/terraform/pull/24887
+      # has been approved and is part of the 0.13 release to resolve the issue
+      # with remote states.
+      # The PR
+      # https://github.com/hashicorp/terraform/pull/24896
+      # is a proprosed fix to deal with `terraform validate` with proxy
+      # providers (among other configurations).
+      # We have decided to disable the terraform_validate hook until the issues
+      # above have been resolved, which we hope will be with the release of
+      # Terraform 0.13.
+      # - id: terraform_validate
   - repo: https://github.com/IamTheFij/docker-pre-commit
     rev: v1.0.1
     hooks:
       - id: docker-compose-check
   - repo: https://github.com/prettier/prettier
-    rev: 1.19.1
+    rev: 2.0.5
     hooks:
       - id: prettier
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.761
+    rev: v0.770
     hooks:
       - id: mypy

--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ Note that step-by-step bootstrapping instructions are given in the
 account-specific `README.md` files found in the account
 subdirectories.
 
+## Notes ##
+
+Running `pre-commit` requires running `terraform init` in every directory that
+contains Terraform code. In this repository, these are the main directory and
+every directory under `examples/`.
+
 ## Contributing ##
 
 We welcome contributions!  Please see [here](CONTRIBUTING.md) for

--- a/README.md
+++ b/README.md
@@ -44,9 +44,11 @@ subdirectories.
 
 ## Notes ##
 
-Running `pre-commit` requires running `terraform init` in every directory that
-contains Terraform code. In this repository, these are the main directory and
-every directory under `examples/`.
+Running `pre-commit` requires running `terraform init` in every
+directory that contains Terraform code. In this repository, this
+includes each account directory (e.g. `audit/`, `dns/`, `dynamic/`,
+etc.), as well as `provisionaccount-role-tf-module` and every
+directory under its `examples/` directory.
 
 ## Contributing ##
 

--- a/audit/README.md
+++ b/audit/README.md
@@ -55,21 +55,31 @@ At this point the account has been bootstrapped, and you can apply
 future changes by simply running `terraform apply
 -var-file=<workspace_name>.tfvars`.
 
+## Requirements ##
+
+| Name | Version |
+|------|---------|
+| terraform | >= 0.12 |
+
+## Providers ##
+
+No provider.
+
 ## Inputs ##
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-------:|:--------:|
-| aws_region | The AWS region where the non-global resources for the Audit account are to be created (e.g. us-east-1). | string | `us-east-1` | no |
-| provisionaccount_role_description | The description to associate with the IAM role that allows sufficient access to provision all AWS resources in the Audit account. | string | `Allows sufficient access to provision all AWS resources in the Audit account.` | no |
-| provisionaccount_role_name | The name to assign the IAM role that allows sufficient permissions to provision all AWS resources in the Audit account. | string | `ProvisionAccount` | no |
-| tags | Tags to apply to all AWS resources created. | map(string) | `{}` | no |
-| users_account_id | The ID of the users account.  This account will be allowed to assume the role that allows sufficient access to provision all AWS resources in the Audit account. | string | | yes |
+|------|-------------|------|---------|:--------:|
+| aws_region | The AWS region where the non-global resources for the Audit account are to be provisioned (e.g. "us-east-1"). | `string` | `us-east-1` | no |
+| provisionaccount_role_description | The description to associate with the IAM role that allows sufficient permissions to provision all AWS resources in the Audit account. | `string` | `Allows sufficient permissions to provision all AWS resources in the Audit account.` | no |
+| provisionaccount_role_name | The name to assign the IAM role that allows sufficient permissions to provision all AWS resources in the Audit account. | `string` | `ProvisionAccount` | no |
+| tags | Tags to apply to all AWS resources provisioned. | `map(string)` | `{}` | no |
+| users_account_id | The ID of the users account.  This account will be allowed to assume the role that allows sufficient permissions to provision all AWS resources in the Audit account. | `string` | n/a | yes |
 
 ## Outputs ##
 
 | Name | Description |
 |------|-------------|
-| provisionaccount_role | The IAM role that allows sufficient permissions to create all AWS resources in the Audit account. |
+| provisionaccount_role | The IAM role that allows sufficient permissions to provision all AWS resources in the Audit account. |
 
 ## Contributing ##
 

--- a/dns/README.md
+++ b/dns/README.md
@@ -55,17 +55,29 @@ At this point the account has been bootstrapped, and you can apply
 future changes by simply running `terraform apply
 -var-file=<workspace_name>.tfvars`.
 
+## Requirements ##
+
+| Name | Version |
+|------|---------|
+| terraform | >= 0.12 |
+
+## Providers ##
+
+| Name | Version |
+|------|---------|
+| aws | n/a |
+
 ## Inputs ##
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:-----:|
+|------|-------------|------|---------|:--------:|
 | aws_region | The AWS region where the non-global resources for the DNS account are to be provisioned (e.g. "us-east-1"). | `string` | `us-east-1` | no |
 | provisionaccount_role_description | The description to associate with the IAM role that allows sufficient permissions to provision all AWS resources in the DNS account. | `string` | `Allows sufficient permissions to provision all AWS resources in the DNS account.` | no |
 | provisionaccount_role_name | The name to assign the IAM role that allows sufficient permissions to provision all AWS resources in the DNS account. | `string` | `ProvisionAccount` | no |
 | provisionroute53_role_description | The description to associate with the IAM role (as well as the corresponding policy) that allows sufficient permissions to provision Route 53 in the DNS account. | `string` | `Allows sufficient permissions to provision Route 53 in the DNS account.` | no |
 | provisionroute53_role_name | The name to assign the IAM role (as well as the corresponding policy) that allows sufficient permissions to provision Route 53 in the DNS account. | `string` | `ProvisionRoute53` | no |
 | tags | Tags to apply to all AWS resources provisioned. | `map(string)` | `{}` | no |
-| users_account_id | The ID of the users account.  This account will be allowed to assume the role that allows sufficient permissions to provision all AWS resources in the DNS account. | `any` | n/a | yes |
+| users_account_id | The ID of the users account.  This account will be allowed to assume the role that allows sufficient permissions to provision all AWS resources in the DNS account. | `string` | n/a | yes |
 
 ## Outputs ##
 

--- a/dynamic/README.md
+++ b/dynamic/README.md
@@ -54,16 +54,26 @@ At this point the account has been bootstrapped, and you can apply
 future changes by simply running `terraform apply
 -var-file=<workspace_name>.tfvars`.
 
+## Requirements ##
+
+| Name | Version |
+|------|---------|
+| terraform | >= 0.12 |
+
+## Providers ##
+
+No provider.
+
 ## Inputs ##
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:-----:|
-| aws_region | The AWS region where the non-global resources for the dynamic account are to be provisioned (e.g. "us-east-1"). | string | `us-east-1` | no |
-| dynamic_account_name |  The name of the dynamic account to be provisioned. | string | | yes |
-| provisionaccount_role_description | The description to associate with the IAM role that allows sufficient permissions to provision all AWS resources in the dynamic account. | string | `Allows sufficient permissions to provision all AWS resources in the dynamic account.` | no |
-| provisionaccount_role_name | The name to assign the IAM role that allows sufficient permissions to provision all AWS resources in the dynamic account. | string | `ProvisionAccount` | no |
-| tags | Tags to apply to all AWS resources provisioned. | map(string) | `{}` | no |
-| users_account_id | The ID of the users account.  This account will be allowed to assume the role that allows sufficient permissions to provision all AWS resources in the dynamic account. | string | | yes |
+|------|-------------|------|---------|:--------:|
+| aws_region | The AWS region where the non-global resources for the dynamic account are to be provisioned (e.g. "us-east-1"). | `string` | `us-east-1` | no |
+| dynamic_account_name | The name of the dynamic account to be provisioned. | `string` | n/a | yes |
+| provisionaccount_role_description | The description to associate with the IAM role that allows sufficient permissions to provision all AWS resources in the dynamic account. | `string` | `Allows sufficient permissions to provision all AWS resources in the dynamic account.` | no |
+| provisionaccount_role_name | The name to assign the IAM role that allows sufficient permissions to provision all AWS resources in the dynamic account. | `string` | `ProvisionAccount` | no |
+| tags | Tags to apply to all AWS resources provisioned. | `map(string)` | `{}` | no |
+| users_account_id | The ID of the users account.  This account will be allowed to assume the role that allows sufficient permissions to provision all AWS resources in the dynamic account. | `string` | n/a | yes |
 
 ## Outputs ##
 

--- a/images/README.md
+++ b/images/README.md
@@ -60,33 +60,46 @@ At this point the account has been bootstrapped, and you can apply
 future changes by simply running `terraform apply
 -var-file=<workspace_name>.tfvars`.
 
+## Requirements ##
+
+| Name | Version |
+|------|---------|
+| terraform | >= 0.12 |
+
+## Providers ##
+
+| Name | Version |
+|------|---------|
+| aws | n/a |
+| aws.organizationsreadonly | n/a |
+
 ## Inputs ##
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-------:|:--------:|
-| administerkmskeys_role_description | The description to associate with the IAM role (as well as the corresponding policy) that allows sufficient permissions to administer all KMS keys in the Images account. | string | `Allows sufficient permissions to administer all KMS keys in the Images account.` | no |
-| administerkmskeys_role_name | The name to assign the IAM role (as well as the corresponding policy) that allows sufficient permissions to administer all KMS keys in the Images account. | string | `AdministerKMSKeys` | no |
-| ami_build_cidr | The CIDR block to assign to the VPC and subnet used to build AMIs. | string | `192.168.100.0/24` | no |
-| ami_kms_key_alias | The alias to assign to the KMS key used to encrypt AMIs in the Images account. | string | `cool-amis` | no |
-| ami_kms_key_description | The description to assign to the KMS key used to encrypt AMIs in the Images account. | string | `The key used to encrypt AMIs in this account.` | no |
-| aws_region | The AWS region where the non-global resources for the Images account are to be created (e.g. us-east-1). | string | `us-east-1` | no |
-| ec2amicreate_role_description | The description to associate with the IAM role (as well as the corresponding policy) that allows sufficient permissions to create AMIs. | string | `Allows sufficient permissions to create AMIs.` | no |
-| ec2amicreate_role_name | The name to assign the IAM role (as well as the corresponding policy) that allows sufficient permissions to create AMIs. | string | `EC2AMICreate` | no |
-| provisionaccount_role_description | The description to associate with the IAM role that allows sufficient access to provision all AWS resources in the Images account. | string | `Allows sufficient access to provision all AWS resources in the Images account.` | no |
-| provisionaccount_role_name | The name to assign the IAM role that allows sufficient permissions to provision all AWS resources in the Images account. | string | `ProvisionAccount` | no |
-| provisionec2amicreateroles_role_description | The description to associate with the IAM role (as well as the corresponding policy) with the ability to create IAM roles that can create AMIs in the Images account. | string | `Allows creation of IAM roles that can create AMIs in the Images account` | no |
-| provisionec2amicreateroles_role_name | The name to assign the IAM role (as well as the corresponding policy) with the ability to create IAM roles that can create AMIs in the Images account. | string | `ProvisionEC2AMICreateRoles` | no |
-| provisionkmskeys_role_description | The description to associate with the IAM role (as well as the corresponding policy) that allows sufficient permissions to provision KMS keys in the Images account. | string | `Allows sufficient permissions to provision KMS keys in the Images account.` | no |
-| provisionkmskeys_role_name | The name to assign the IAM role (as well as the corresponding policy) that allows sufficient permissions to provision KMS keys in the Images account. | string | `ProvisionKMSKeys` | no |
-| provisionthirdpartybucket_policy_description | The description to associate with the IAM policy that allows sufficient permissions to provision the third-party file storage S3 bucket in the Images account. | string | `Allows sufficient permissions to provision the third-party file storage S3 bucket in the Images account.` | no |
-| provisionthirdpartybucket_policy_name | The name to assign the IAM policy that allows sufficient permissions to provision the third-party file storage S3 bucket in the Images account. | string | `ProvisionThirdPartyBucket` | no |
-| provisionthirdpartybucketreadroles_role_description | The description to associate with the IAM role (as well as the corresponding policy) with the ability to create IAM roles that can read objects in the third-party file storage S3 bucket in the Images account. | string | `Allows creation of IAM roles that can read objects in the third-party file storage S3 bucket in the Images account.` | no |
-| provisionthirdpartybucketreadroles_role_name | The name to assign the IAM role (as well as the corresponding policy) with the ability to create IAM roles that can read objects in the third-party file storage S3 bucket in the Images account. | string | `ProvisionThirdPartyBucketReadRoles` | no |
-| provisionvpcs_policy_description | The description to associate with the IAM policy that allows sufficient permissions to provision VPCs (and related resources) in the Images account. | string | `Allows sufficient permissions to provision VPCs (and related resources) in the Images account` | no |
-| provisionvpcs_policy_name | The name to assign the IAM policy that allows sufficient permissions to provision VPCs (and related resources) in the Images account. | string | `ProvisionVPCs` | no |
-| tags | Tags to apply to all AWS resources created. | map(string) | `{}` | no |
-| third_party_bucket_name_prefix | The prefix to use to name the S3 bucket for storing third-party files.  The bucket will be named with this prefix plus the account type (e.g. production or staging). | string | `cisa-cool-third-party` | no |
-| users_account_id | The ID of the users account.  This account will be allowed to assume the role that allows sufficient access to provision all AWS resources in the Images account, as well as the role that allows sufficient permissions to create AWS EC2 AMIs in the Images account. | string | | yes |
+|------|-------------|------|---------|:--------:|
+| administerkmskeys_role_description | The description to associate with the IAM role (as well as the corresponding policy) that allows sufficient permissions to administer all KMS keys in the Images account. | `string` | `Allows sufficient permissions to administer all KMS keys in the Images account.` | no |
+| administerkmskeys_role_name | The name to assign the IAM role (as well as the corresponding policy) that allows sufficient permissions to administer all KMS keys in the Images account. | `string` | `AdministerKMSKeys` | no |
+| ami_build_cidr | The CIDR block to assign to the VPC and subnet used to build AMIs. | `string` | `192.168.100.0/24` | no |
+| ami_kms_key_alias | The alias to assign to the KMS key used to encrypt AMIs in the Images account. | `string` | `cool-amis` | no |
+| ami_kms_key_description | The description to assign to the KMS key used to encrypt AMIs in the Images account. | `string` | `The key used to encrypt AMIs in this account.` | no |
+| aws_region | The AWS region where the non-global resources for the Images account are to be provisioned (e.g. "us-east-1"). | `string` | `us-east-1` | no |
+| ec2amicreate_role_description | The description to associate with the IAM role (as well as the corresponding policy) that allows sufficient permissions to create AMIs in the Images account. | `string` | `Allows sufficient permissions to create AMIs in the Images account.` | no |
+| ec2amicreate_role_name | The name to assign the IAM role (as well as the corresponding policy) that allows sufficient permissions to create AMIs in the Images account. | `string` | `EC2AMICreate` | no |
+| provisionaccount_role_description | The description to associate with the IAM role that allows sufficient permissions to provision all AWS resources in the Images account. | `string` | `Allows sufficient permissions to provision all AWS resources in the Images account.` | no |
+| provisionaccount_role_name | The name to assign the IAM role that allows sufficient permissions to provision all AWS resources in the Images account. | `string` | `ProvisionAccount` | no |
+| provisionec2amicreateroles_role_description | The description to associate with the IAM role (as well as the corresponding policy) with the ability to create IAM roles that can create AMIs in the Images account. | `string` | `Allows creation of IAM roles that can create AMIs in the Images account.` | no |
+| provisionec2amicreateroles_role_name | The name to assign the IAM role (as well as the corresponding policy) with the ability to create IAM roles that can create AMIs in the Images account. | `string` | `ProvisionEC2AMICreateRoles` | no |
+| provisionkmskeys_role_description | The description to associate with the IAM role (as well as the corresponding policy) that allows sufficient permissions to provision KMS keys in the Images account. | `string` | `Allows sufficient permissions to provision KMS keys in the Images account.` | no |
+| provisionkmskeys_role_name | The name to assign the IAM role (as well as the corresponding policy) that allows sufficient permissions to provision KMS keys in the Images account. | `string` | `ProvisionKMSKeys` | no |
+| provisionthirdpartybucket_policy_description | The description to associate with the IAM policy that allows sufficient permissions to provision the third-party file storage S3 bucket in the Images account. | `string` | `Allows sufficient permissions to provision the third-party file storage S3 bucket in the Images account.` | no |
+| provisionthirdpartybucket_policy_name | The name to assign the IAM policy that allows sufficient permissions to provision the third-party file storage S3 bucket in the Images account. | `string` | `ProvisionThirdPartyBucket` | no |
+| provisionthirdpartybucketreadroles_role_description | The description to associate with the IAM role (as well as the corresponding policy) with the ability to create IAM roles that can read objects in the third-party file storage S3 bucket in the Images account. | `string` | `Allows creation of IAM roles that can read objects in the third-party file storage S3 bucket in the Images account.` | no |
+| provisionthirdpartybucketreadroles_role_name | The name to assign the IAM role (as well as the corresponding policy) with the ability to create IAM roles that can read objects in the third-party file storage S3 bucket in the Images account. | `string` | `ProvisionThirdPartyBucketReadRoles` | no |
+| provisionvpcs_policy_description | The description to associate with the IAM policy that allows sufficient permissions to provision VPCs (and related resources) in the Images account. | `string` | `Allows sufficient permissions to provision VPCs (and related resources) in the Images account.` | no |
+| provisionvpcs_policy_name | The name to assign the IAM policy that allows sufficient permissions to provision VPCs (and related resources) in the Images account. | `string` | `ProvisionVPCs` | no |
+| tags | Tags to apply to all AWS resources provisioned. | `map(string)` | `{}` | no |
+| third_party_bucket_name_prefix | The prefix to use to name the S3 bucket for storing third-party files.  The bucket will be named with this prefix plus the account type (e.g. production or staging). | `string` | `cisa-cool-third-party` | no |
+| users_account_id | The ID of the users account.  This account will be allowed to assume the role that allows sufficient permissions to provision all AWS resources in the Images account. | `string` | n/a | yes |
 
 ## Outputs ##
 

--- a/log-archive/README.md
+++ b/log-archive/README.md
@@ -56,21 +56,31 @@ At this point the account has been bootstrapped, and you can apply
 future changes by simply running `terraform apply
 -var-file=<workspace_name>.tfvars`.
 
+## Requirements ##
+
+| Name | Version |
+|------|---------|
+| terraform | >= 0.12 |
+
+## Providers ##
+
+No provider.
+
 ## Inputs ##
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-------:|:--------:|
-| aws_region | The AWS region where the non-global resources for the Log Archive account are to be created (e.g. us-east-1). | string | `us-east-1` | no |
-| provisionaccount_role_description | The description to associate with the IAM role that allows sufficient access to provision all AWS resources in the Log Archive account. | string | `Allows sufficient access to provision all AWS resources in the Log Archive account.` | no |
-| provisionaccount_role_name | The name to assign the IAM role that allows sufficient permissions to provision all AWS resources in the Log Archive account. | string | `ProvisionAccount` | no |
-| tags | Tags to apply to all AWS resources created. | map(string) | `{}` | no |
-| users_account_id | The ID of the users account.  This account will be allowed to assume the role that allows sufficient access to provision all AWS resources in the Log Archive account. | string | | yes |
+|------|-------------|------|---------|:--------:|
+| aws_region | The AWS region where the non-global resources for the Log Archive account are to be provisioned (e.g. "us-east-1"). | `string` | `us-east-1` | no |
+| provisionaccount_role_description | The description to associate with the IAM role that allows sufficient permissions to provision all AWS resources in the Log Archive account. | `string` | `Allows sufficient permissions to provision all AWS resources in the Log Archive account.` | no |
+| provisionaccount_role_name | The name to assign the IAM role that allows sufficient permissions to provision all AWS resources in the Log Archive account. | `string` | `ProvisionAccount` | no |
+| tags | Tags to apply to all AWS resources provisioned. | `map(string)` | `{}` | no |
+| users_account_id | The ID of the users account.  This account will be allowed to assume the role that allows sufficient permissions to provision all AWS resources in the Log Archive account. | `string` | n/a | yes |
 
 ## Outputs ##
 
 | Name | Description |
 |------|-------------|
-| provisionaccount_role | The IAM role that allows sufficient permissions to create all AWS resources in the Log Archive account. |
+| provisionaccount_role | The IAM role that allows sufficient permissions to provision all AWS resources in the Log Archive account. |
 
 ## Contributing ##
 

--- a/master/README.md
+++ b/master/README.md
@@ -55,24 +55,36 @@ At this point the account has been bootstrapped, and you can apply
 future changes by simply running `terraform apply
 -var-file=<workspace_name>.tfvars`.
 
+## Requirements ##
+
+| Name | Version |
+|------|---------|
+| terraform | >= 0.12 |
+
+## Providers ##
+
+| Name | Version |
+|------|---------|
+| aws | n/a |
+
 ## Inputs ##
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-------:|:--------:|
-| aws_region | The AWS region where the non-global resources for the Master account are to be created (e.g. us-east-1). | string | `us-east-1` | no |
-| organizationsreadonly_role_description | The description to associate with the IAM role that allows read-only access to all AWS Organizations information in the Master account. | string | `Allows read-only access to all AWS Organizations information in the Master account.` | no |
-| organizationsreadonly_role_name | The name to assign the IAM role that allows read-only access to all AWS Organizations information in the Master account. | string | `OrganizationsReadOnly` | no |
-| provisionaccount_role_description | The description to associate with the IAM role that allows sufficient access to provision all AWS resources in the Master account. | string | `Allows sufficient access to provision all AWS resources in the Master account.` | no |
-| provisionaccount_role_name | The name to assign the IAM role that allows sufficient permissions to provision all AWS resources in the Master account. | string | `ProvisionAccount` | no |
-| tags | Tags to apply to all AWS resources created. | map(string) | `{}` | no |
-| users_account_id | The ID of the users account.  This account will be allowed to assume the role that allows sufficient access to provision all AWS resources in the Master account. | string | | yes |
+|------|-------------|------|---------|:--------:|
+| aws_region | The AWS region where the non-global resources for the Master account are to be provisioned (e.g. "us-east-1"). | `string` | `us-east-1` | no |
+| organizationsreadonly_role_description | The description to associate with the IAM role that allows read-only access to all AWS Organizations information in the Master account. | `string` | `Allows read-only access to all AWS Organizations information in the Master account.` | no |
+| organizationsreadonly_role_name | The name to assign the IAM role that allows read-only access to all AWS Organizations information in the Master account. | `string` | `OrganizationsReadOnly` | no |
+| provisionaccount_role_description | The description to associate with the IAM role that allows sufficient permissions to provision all AWS resources in the Master account. | `string` | `Allows sufficient permissions to provision all AWS resources in the Master account.` | no |
+| provisionaccount_role_name | The name to assign the IAM role that allows sufficient permissions to provision all AWS resources in the Master account. | `string` | `ProvisionAccount` | no |
+| tags | Tags to apply to all AWS resources provisioned. | `map(string)` | `{}` | no |
+| users_account_id | The ID of the users account.  This account will be allowed to assume the role that allows sufficient permissions to provision all AWS resources in the Master account. | `string` | n/a | yes |
 
 ## Outputs ##
 
 | Name | Description |
 |------|-------------|
 | organizationsreadonly_role | The IAM role that allows read-only access to all AWS Organizations information in the Master account. |
-| provisionaccount_role | The IAM role that allows sufficient permissions to create all AWS resources in the Master account. |
+| provisionaccount_role | The IAM role that allows sufficient permissions to provision all AWS resources in the Master account. |
 
 ## Contributing ##
 

--- a/providers.tf
+++ b/providers.tf
@@ -1,0 +1,4 @@
+# Default provider information.
+provider "aws" {
+  region = var.aws_region
+}

--- a/provisionaccount-role-tf-module/README.md
+++ b/provisionaccount-role-tf-module/README.md
@@ -31,15 +31,27 @@ module "provisionaccount" {
 
 * [Basic usage](https://github.com/cisagov/cool-accounts/tree/develop/provisionaccount-role-tf-module/examples/basic_usage)
 
+## Requirements ##
+
+| Name | Version |
+|------|---------|
+| terraform | >= 0.12 |
+
+## Providers ##
+
+| Name | Version |
+|------|---------|
+| aws | n/a |
+
 ## Inputs ##
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-------:|:--------:|
-| aws_region | The AWS region where the non-global resources for this account are to be created (e.g. us-east-1). | string | `us-east-1` | no |
-| provisionaccount_role_description | The description to associate with the IAM role that allows sufficient access to provision all AWS resources in the new account (e.g. "Allows sufficient permissions to provision all AWS resources in the DNS account."). | string | | yes |
-| provisionaccount_role_name | The name to assign the IAM role that allows sufficient permissions to provision all AWS resources in the new account (e.g. "ProvisionAccount"). | string | | yes |
-| tags | Tags to apply to all AWS resources created. | map(string) | `{}` | no |
-| users_account_id | The ID of the users account.  This account will be allowed to assume the role that allows sufficient permissions to provision all AWS resources in the new account. | string | | yes |
+|------|-------------|------|---------|:--------:|
+| aws_region | The AWS region where the non-global resources for the new account are to be provisioned (e.g. "us-east-1"). | `string` | `us-east-1` | no |
+| provisionaccount_role_description | The description to associate with the IAM role that allows sufficient permissions to provision all AWS resources in the new account (e.g. "Allows sufficient permissions to provision all AWS resources in the DNS account."). | `string` | n/a | yes |
+| provisionaccount_role_name | The name to assign the IAM role that allows sufficient permissions to provision all AWS resources in the new account (e.g. "ProvisionAccount"). | `string` | n/a | yes |
+| tags | Tags to apply to all AWS resources provisioned. | `map(string)` | `{}` | no |
+| users_account_id | The ID of the users account.  This account will be allowed to assume the role that allows sufficient permissions to provision all AWS resources in the new account. | `string` | n/a | yes |
 
 ## Outputs ##
 

--- a/provisionaccount-role-tf-module/examples/basic_usage/README.md
+++ b/provisionaccount-role-tf-module/examples/basic_usage/README.md
@@ -56,21 +56,32 @@ At this point the account has been bootstrapped, and you can apply
 future changes by simply running `terraform apply
 -var-file=<workspace_name>.tfvars`.
 
+## Requirements ##
+
+| Name | Version |
+|------|---------|
+| terraform | >= 0.12 |
+
+## Providers ##
+
+No provider.
+
 ## Inputs ##
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-------:|:--------:|
-| aws_region | The AWS region where the non-global resources for the Pettifogger0 account are to be created (e.g. us-east-1). | string | `us-east-1` | no |
-| provisionaccount_role_description | The description to associate with the IAM role that allows sufficient access to provision all AWS resources in the Pettifogger0 account. | string | `Allows sufficient access to provision all AWS resources in the Pettifogger0 account.` | no |
-| provisionaccount_role_name | The name to assign the IAM role that allows sufficient permissions to provision all AWS resources in Pettifogger0 account. | string | `ProvisionAccount` | no |
-| tags | Tags to apply to all AWS resources created. | map(string) | `{}` | no |
-| users_account_id | The ID of the users account.  This account will be allowed to assume the role that allows sufficient access to provision all AWS resources in the Pettifogger0 account. | string | | yes |
+|------|-------------|------|---------|:--------:|
+| aws_region | The AWS region where the non-global resources for the Pettifogger0 account are to be provisioned (e.g. "us-east-1"). | `string` | `us-east-1` | no |
+| provisionaccount_role_description | The description to associate with the IAM role that allows sufficient permissions to provision all AWS resources in the Pettifogger0 account. | `string` | `Allows sufficient permissions to provision all AWS resources in the Pettifogger0 account.` | no |
+| provisionaccount_role_name | The name to assign the IAM role that allows sufficient permissions to provision all AWS resources in the Pettifogger0 account. | `string` | `ProvisionAccount` | no |
+| tags | Tags to apply to all AWS resources provisioned. | `map(string)` | `{}` | no |
+| this_account_id | The ID of the account being configured. | `string` | n/a | yes |
+| users_account_id | The ID of the users account.  This account will be allowed to assume the role that allows sufficient permissions to provision all AWS resources in the Pettifogger0 account. | `string` | n/a | yes |
 
 ## Outputs ##
 
 | Name | Description |
 |------|-------------|
-| provisionaccount_role_arn | The ARN of the IAM role that allows sufficient permissions to create all AWS resources in the Pettifogger0 account. |
+| provisionaccount_role_arn | The ARN of the IAM role that allows sufficient permissions to provision all AWS resources in the Pettifogger0 account. |
 
 ## Contributing ##
 

--- a/provisionaccount-role-tf-module/examples/basic_usage/provisionaccount.tf
+++ b/provisionaccount-role-tf-module/examples/basic_usage/provisionaccount.tf
@@ -1,5 +1,5 @@
 module "provisionaccount" {
-  source = "../provisionaccount-role-tf-module"
+  source = "../.."
 
   provisionaccount_role_description = var.provisionaccount_role_description
   provisionaccount_role_name        = var.provisionaccount_role_name

--- a/shared-services/README.md
+++ b/shared-services/README.md
@@ -63,6 +63,10 @@ future changes by simply running `terraform apply
 | aws_region | The AWS region where the non-global resources for the Shared Services account are to be created (e.g. us-east-1). | string | `us-east-1` | no |
 | provisionaccount_role_description | The description to associate with the IAM role that allows sufficient access to provision all AWS resources in the Shared Services account. | string | `Allows sufficient access to provision all AWS resources in the Shared Services account.` | no |
 | provisionaccount_role_name | The name to assign the IAM role that allows sufficient permissions to provision all AWS resources in the Shared Services account. | string | `ProvisionAccount` | no |
+| provisionssmdocument_policy_description | The description to associate with the IAM policy that allows sufficient permissions to provision the SSM Document resource in the Shared Services account. | `string` | `Allows sufficient permissions to provision the SSM Document resource in the Shared Services account.` | no |
+| provisionssmdocument_policy_name | The name to assign the IAM policy that allows sufficient permissions to provision the SSM Document resource in the Shared Services account. | `string` | `ProvisionSSMDocument` | no |
+| ssmsession_role_description | The description to associate with the IAM role (and policy) that allows creation of SSM SessionManager sessions to any EC2 instance in this account. | `string` | `Allows creation of SSM SessionManager sessions to any EC2 instance in this account.` | no |
+| ssmsession_role_name | The name to assign the IAM role (and policy) that allows creation of SSM SessionManager sessions to any EC2 instance in this account. | `string` | `StartStopSSMSession` | no |
 | tags | Tags to apply to all AWS resources created. | map(string) | `{}` | no |
 | users_account_id | The ID of the users account.  This account will be allowed to assume the role that allows sufficient access to provision all AWS resources in the Shared Services account. | string | | yes |
 

--- a/shared-services/README.md
+++ b/shared-services/README.md
@@ -56,25 +56,37 @@ At this point the account has been bootstrapped, and you can apply
 future changes by simply running `terraform apply
 -var-file=<workspace_name>.tfvars`.
 
+## Requirements ##
+
+| Name | Version |
+|------|---------|
+| terraform | >= 0.12 |
+
+## Providers ##
+
+| Name | Version |
+|------|---------|
+| aws | n/a |
+
 ## Inputs ##
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-------:|:--------:|
-| aws_region | The AWS region where the non-global resources for the Shared Services account are to be created (e.g. us-east-1). | string | `us-east-1` | no |
-| provisionaccount_role_description | The description to associate with the IAM role that allows sufficient access to provision all AWS resources in the Shared Services account. | string | `Allows sufficient access to provision all AWS resources in the Shared Services account.` | no |
-| provisionaccount_role_name | The name to assign the IAM role that allows sufficient permissions to provision all AWS resources in the Shared Services account. | string | `ProvisionAccount` | no |
+|------|-------------|------|---------|:--------:|
+| aws_region | The AWS region where the non-global resources for the Shared Services account are to be provisioned (e.g. "us-east-1"). | `string` | `us-east-1` | no |
+| provisionaccount_role_description | The description to associate with the IAM role that allows sufficient permissions to provision all AWS resources in the Shared Services account. | `string` | `Allows sufficient permissions to provision all AWS resources in the Shared Services account.` | no |
+| provisionaccount_role_name | The name to assign the IAM role that allows sufficient permissions to provision all AWS resources in the Shared Services account. | `string` | `ProvisionAccount` | no |
 | provisionssmdocument_policy_description | The description to associate with the IAM policy that allows sufficient permissions to provision the SSM Document resource in the Shared Services account. | `string` | `Allows sufficient permissions to provision the SSM Document resource in the Shared Services account.` | no |
 | provisionssmdocument_policy_name | The name to assign the IAM policy that allows sufficient permissions to provision the SSM Document resource in the Shared Services account. | `string` | `ProvisionSSMDocument` | no |
 | ssmsession_role_description | The description to associate with the IAM role (and policy) that allows creation of SSM SessionManager sessions to any EC2 instance in this account. | `string` | `Allows creation of SSM SessionManager sessions to any EC2 instance in this account.` | no |
 | ssmsession_role_name | The name to assign the IAM role (and policy) that allows creation of SSM SessionManager sessions to any EC2 instance in this account. | `string` | `StartStopSSMSession` | no |
-| tags | Tags to apply to all AWS resources created. | map(string) | `{}` | no |
-| users_account_id | The ID of the users account.  This account will be allowed to assume the role that allows sufficient access to provision all AWS resources in the Shared Services account. | string | | yes |
+| tags | Tags to apply to all AWS resources provisioned. | `map(string)` | `{}` | no |
+| users_account_id | The ID of the users account.  This account will be allowed to assume the role that allows sufficient permissions to provision all AWS resources in the Shared Services account. | `string` | n/a | yes |
 
 ## Outputs ##
 
 | Name | Description |
 |------|-------------|
-| provisionaccount_role | The IAM role that allows sufficient permissions to create all AWS resources in the Shared Services account. |
+| provisionaccount_role | The IAM role that allows sufficient permissions to provision all AWS resources in the Shared Services account. |
 | ssmsession_role | The IAM role that allows creation of SSM SessionManager sessions to any EC2 instance in this account. |
 
 ## Contributing ##

--- a/shared-services/README.md
+++ b/shared-services/README.md
@@ -75,6 +75,7 @@ future changes by simply running `terraform apply
 | Name | Description |
 |------|-------------|
 | provisionaccount_role | The IAM role that allows sufficient permissions to create all AWS resources in the Shared Services account. |
+| ssmsession_role | The IAM role that allows creation of SSM SessionManager sessions to any EC2 instance in this account. |
 
 ## Contributing ##
 

--- a/shared-services/assume_role_policy_doc.tf
+++ b/shared-services/assume_role_policy_doc.tf
@@ -1,0 +1,19 @@
+# ------------------------------------------------------------------------------
+# Create an IAM policy document that allows the users account to
+# assume this role.
+# ------------------------------------------------------------------------------
+
+data "aws_iam_policy_document" "assume_role_doc" {
+  statement {
+    actions = [
+      "sts:AssumeRole",
+    ]
+
+    principals {
+      type = "AWS"
+      identifiers = [
+        var.users_account_id,
+      ]
+    }
+  }
+}

--- a/shared-services/caller_identity.tf
+++ b/shared-services/caller_identity.tf
@@ -1,0 +1,6 @@
+# ------------------------------------------------------------------------------
+# We can get the account ID of the Shared Services account from the
+# provider's caller identity.
+# ------------------------------------------------------------------------------
+data "aws_caller_identity" "sharedservices" {
+}

--- a/shared-services/outputs.tf
+++ b/shared-services/outputs.tf
@@ -2,3 +2,8 @@ output "provisionaccount_role" {
   value       = module.provisionaccount.provisionaccount_role
   description = "The IAM role that allows sufficient permissions to provision all AWS resources in the Shared Services account."
 }
+
+output "ssmsession_role" {
+  value       = aws_iam_role.ssmsession_role
+  description = "The IAM role that allows creation of SSM SessionManager sessions to any EC2 instance in this account."
+}

--- a/shared-services/provisionssmdocument_policy.tf
+++ b/shared-services/provisionssmdocument_policy.tf
@@ -1,0 +1,26 @@
+# ------------------------------------------------------------------------------
+# Create the IAM policy that allows all of the permissions necessary
+# to provision the SSM Document resource required in this account.
+# ------------------------------------------------------------------------------
+
+data "aws_iam_policy_document" "provisionssmdocument_policy_doc" {
+  statement {
+    actions = [
+      "ssm:CreateDocument",
+      "ssm:DeleteDocument",
+      "ssm:DescribeDocument*",
+      "ssm:GetDocument",
+      "ssm:UpdateDocument*",
+    ]
+
+    resources = [
+      "arn:aws:ssm:${var.aws_region}:${data.aws_caller_identity.sharedservices.account_id}:document/SSM-SessionManagerRunShell",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "provisionssmdocument_policy" {
+  description = var.provisionssmdocument_policy_description
+  name        = var.provisionssmdocument_policy_name
+  policy      = data.aws_iam_policy_document.provisionssmdocument_policy_doc.json
+}

--- a/shared-services/provisionssmdocument_policy_attachment.tf
+++ b/shared-services/provisionssmdocument_policy_attachment.tf
@@ -1,0 +1,9 @@
+# ------------------------------------------------------------------------------
+# Attach to the ProvisionAccount role the IAM policy that allows
+# provisioning of the SSM Document resource required in this account.
+# ------------------------------------------------------------------------------
+
+resource "aws_iam_role_policy_attachment" "provisionssmdocument_policy_attachment" {
+  policy_arn = aws_iam_policy.provisionssmdocument_policy.arn
+  role       = module.provisionaccount.provisionaccount_role.name
+}

--- a/shared-services/run_shell_ssm_document.tf
+++ b/shared-services/run_shell_ssm_document.tf
@@ -1,0 +1,7 @@
+# ------------------------------------------------------------------------------
+# Create an SSM Document that allows creation of SSM SessionManager
+# sessions in this account.
+# ------------------------------------------------------------------------------
+module "run_shell_ssm_document" {
+  source = "gazoakley/session-manager-settings/aws"
+}

--- a/shared-services/ssm_session_policy.tf
+++ b/shared-services/ssm_session_policy.tf
@@ -1,0 +1,69 @@
+# ------------------------------------------------------------------------------
+# Create the IAM policy that allows creation of SSM SessionManager
+# sessions to any EC2 instance in this account.
+# ------------------------------------------------------------------------------
+
+data "aws_iam_policy_document" "ssmsession_doc" {
+  # Allow the user to start a session
+  statement {
+    actions = [
+      "ssm:SendCommand",
+      "ssm:StartSession",
+    ]
+    resources = [
+      "arn:aws:ec2:${var.aws_region}:${data.aws_caller_identity.sharedservices.account_id}:instance/*",
+      "arn:aws:ssm:${var.aws_region}::document/AWS-StartPortForwardingSession",
+      "arn:aws:ssm:${var.aws_region}::document/AWS-StartSSHSession",
+      "arn:aws:ssm:${var.aws_region}:${data.aws_caller_identity.sharedservices.account_id}:document/SSM-SessionManagerRunShell",
+    ]
+    condition {
+      test     = "BoolIfExists"
+      variable = "ssm:SessionDocumentAccessCheck"
+      values = [
+        true,
+      ]
+    }
+  }
+
+  # Allow the user to read documents
+  statement {
+    actions = [
+      "ssm:GetDocument",
+    ]
+    resources = [
+      "arn:aws:ssm:${var.aws_region}::document/AWS-StartPortForwardingSession",
+      "arn:aws:ssm:${var.aws_region}::document/AWS-StartSSHSession",
+      "arn:aws:ssm:${var.aws_region}:${data.aws_caller_identity.sharedservices.account_id}:document/SSM-SessionManagerRunShell",
+    ]
+  }
+
+  # Allow the user to collect some information
+  statement {
+    actions = [
+      "ec2:DescribeInstances",
+      "ssm:DescribeInstanceInformation",
+      "ssm:DescribeInstanceProperties",
+      "ssm:DescribeSessions",
+      "ssm:GetConnectionStatus",
+    ]
+    resources = [
+      "*",
+    ]
+  }
+
+  # Allow the user to terminate his or her own sessions
+  statement {
+    actions = [
+      "ssm:TerminateSession",
+    ]
+    resources = [
+      "arn:aws:ssm:${var.aws_region}:${data.aws_caller_identity.sharedservices.account_id}:session/&{aws:username}-*",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "ssmsession_policy" {
+  description = var.ssmsession_role_description
+  name        = var.ssmsession_role_name
+  policy      = data.aws_iam_policy_document.ssmsession_doc.json
+}

--- a/shared-services/ssm_session_role.tf
+++ b/shared-services/ssm_session_role.tf
@@ -1,0 +1,16 @@
+# ------------------------------------------------------------------------------
+# Create the IAM role that allows creation of SSM SessionManager
+# sessions to any EC2 instance in this account.
+# ------------------------------------------------------------------------------
+
+resource "aws_iam_role" "ssmsession_role" {
+  assume_role_policy = data.aws_iam_policy_document.assume_role_doc.json
+  description        = var.ssmsession_role_description
+  name               = var.ssmsession_role_name
+  tags               = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "ssmsession_policy_attachment" {
+  policy_arn = aws_iam_policy.ssmsession_policy.arn
+  role       = aws_iam_role.ssmsession_role.name
+}

--- a/shared-services/variables.tf
+++ b/shared-services/variables.tf
@@ -33,6 +33,30 @@ variable "provisionaccount_role_name" {
   default     = "ProvisionAccount"
 }
 
+variable "provisionssmdocument_policy_description" {
+  type        = string
+  description = "The description to associate with the IAM policy that allows sufficient permissions to provision the SSM Document resource in the Shared Services account."
+  default     = "Allows sufficient permissions to provision the SSM Document resource in the Shared Services account."
+}
+
+variable "provisionssmdocument_policy_name" {
+  type        = string
+  description = "The name to assign the IAM policy that allows sufficient permissions to provision the SSM Document resource in the Shared Services account."
+  default     = "ProvisionSSMDocument"
+}
+
+variable "ssmsession_role_description" {
+  type        = string
+  description = "The description to associate with the IAM role (and policy) that allows creation of SSM SessionManager sessions to any EC2 instance in this account."
+  default     = "Allows creation of SSM SessionManager sessions to any EC2 instance in this account."
+}
+
+variable "ssmsession_role_name" {
+  type        = string
+  description = "The name to assign the IAM role (and policy) that allows creation of SSM SessionManager sessions to any EC2 instance in this account."
+  default     = "StartStopSSMSession"
+}
+
 variable "tags" {
   type        = map(string)
   description = "Tags to apply to all AWS resources provisioned."

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -85,25 +85,37 @@ At this point the account has been bootstrapped, and you can apply
 future changes by simply running `terraform apply
 -var-file=<workspace_name>.tfvars`.
 
+## Requirements ##
+
+| Name | Version |
+|------|---------|
+| terraform | >= 0.12 |
+
+## Providers ##
+
+| Name | Version |
+|------|---------|
+| aws | n/a |
+
 ## Inputs ##
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-------:|:--------:|
-| access_terraform_backend_role_description | The description to associate with the IAM role (as well as the corresponding policy) that allows sufficient access to the Terraform S3 bucket and DynamoDB table to use those resources as a Terraform backend. | string | `Allows sufficient access to the Terraform S3 bucket and DynamoDB table to use those resources as a Terraform backend.` | no |
-| access_terraform_backend_role_name | The name to assign the IAM role (as well as the corresponding policy) that allows sufficient access to the Terraform S3 bucket and DynamoDB table to use those resources as a Terraform backend. | string | `AccessTerraformBackend` | no |
-| aws_region | The AWS region where the non-global resources for this account are to be provisioned (e.g. us-east-1). | string | `us-east-1` | no |
-| provisionaccount_role_description | The description to associate with the IAM role that allows sufficient access to provision all AWS resources in the Terraform account. | string | `Allows sufficient access to provision all AWS resources in the Terraform account.` | no |
-| provisionaccount_role_name | The name to assign the IAM role that allows sufficient permissions to provision all AWS resources in the terraform account. | string | `ProvisionAccount` | no |
-| provisionbackend_policy_description | The description to associate with the IAM policy that allows sufficient access to provision the Terraform backend resources in the Terraform account. | string | `Allows sufficient access to provision the Terraform backend resources in the Terraform account.` | no |
-| provisionbackend_policy_name | The name to assign the IAM policy that allows sufficient permissions to provision the Terraform backend resources in the terraform account. | string | `ProvisionBackend` | no |
-| read_terraform_state_role_description | The description to associate with the IAM role (as well as the corresponding policy) that allows read-only access to the S3 bucket where Terraform state is stored. | string | `Allows read-only access to the S3 bucket where Terraform state is stored.` | no |
-| read_terraform_state_role_name | The name to assign the IAM role (as well as the corresponding policy) that allows read-only access to the S3 bucket where Terraform state is stored. | string | `ReadTerraformState` | no |
-| state_bucket_name | The name to use for the S3 bucket that will store the Terraform state. | string | | yes |
-| state_table_name | The name to use for the DynamoDB table that will be used for Terraform state locking. | string | `terraform-state-lock` | no |
-| state_table_read_capacity | The number of read units for the DynamoDB table that will be used for Terraform state locking. | number | `20` | no |
-| state_table_write_capacity | The number of write units for the DynamoDB table that will be used for Terraform state locking. | number | `20` | no |
-| tags | Tags to apply to all AWS resources created. | map(string) | `{}` | no |
-| user_account_id | The ID of the users account.  This account will be allowed to assume the role that allows sufficient access to the Terraform S3 bucket and DynamoDB table to use those resources as a Terraform backend, as well as the role that allows sufficient permissions to provision all AWS resources in the Terraform account. | string | | yes |
+|------|-------------|------|---------|:--------:|
+| access_terraform_backend_role_description | The description to associate with the IAM role (as well as the corresponding policy) that allows sufficient access to the Terraform S3 bucket and DynamoDB table to use those resources as a Terraform backend. | `string` | `Allows sufficient access to the Terraform S3 bucket and DynamoDB table to use those resources as a Terraform backend.` | no |
+| access_terraform_backend_role_name | The name to assign the IAM role (as well as the corresponding policy) that allows sufficient access to the Terraform S3 bucket and DynamoDB table to use those resources as a Terraform backend. | `string` | `AccessTerraformBackend` | no |
+| aws_region | The AWS region where the non-global resources for this account are to be provisioned (e.g. "us-east-1"). | `string` | `us-east-1` | no |
+| provisionaccount_role_description | The description to associate with the IAM role that allows sufficient permissions to provision all AWS resources in the Terraform account. | `string` | `Allows sufficient permissions to provision all AWS resources in the Terraform account.` | no |
+| provisionaccount_role_name | The name to assign the IAM role that allows sufficient permissions to provision all AWS resources in the Terraform account. | `string` | `ProvisionAccount` | no |
+| provisionbackend_policy_description | The description to associate with the IAM policy that allows sufficient permissions to provision the Terraform backend resources in the Terraform account. | `string` | `Allows sufficient permissions to provision the Terraform backend resources in the Terraform account.` | no |
+| provisionbackend_policy_name | The name to assign the IAM policy that allows sufficient permissions to provision the Terraform backend resources in the Terraform account. | `string` | `ProvisionBackend` | no |
+| read_terraform_state_role_description | The description to associate with the IAM role (as well as the corresponding policy) that allows read-only access to the S3 bucket where Terraform state is stored. | `string` | `Allows read-only access to the S3 bucket where Terraform state is stored.` | no |
+| read_terraform_state_role_name | The name to assign the IAM role (as well as the corresponding policy) that allows read-only access to the S3 bucket where Terraform state is stored. | `string` | `ReadTerraformState` | no |
+| state_bucket_name | The name to use for the S3 bucket that will store the Terraform state. | `string` | n/a | yes |
+| state_table_name | The name to use for the DynamoDB table that will be used for Terraform state locking. | `string` | `terraform-state-lock` | no |
+| state_table_read_capacity | The number of read units for the DynamoDB table that will be used for Terraform state locking. | `number` | `20` | no |
+| state_table_write_capacity | The number of write units for the DynamoDB table that will be used for Terraform state locking. | `number` | `20` | no |
+| tags | Tags to apply to all AWS resources provisioned. | `map(string)` | `{}` | no |
+| users_account_id | The ID of the users account.  This account will be allowed to assume the role that allows sufficient access to the Terraform S3 bucket and DynamoDB table to use those resources as a Terraform backend, as well as the role that allows sufficient permissions to provision all AWS resources in the Terraform account. | `string` | n/a | yes |
 
 ## Outputs ##
 

--- a/users/README.md
+++ b/users/README.md
@@ -60,18 +60,30 @@ At this point the account has been bootstrapped, and you can apply
 future changes by simply running `terraform apply
 -var-file=<workspace_name>.tfvars`.
 
+## Requirements ##
+
+| Name | Version |
+|------|---------|
+| terraform | >= 0.12 |
+
+## Providers ##
+
+| Name | Version |
+|------|---------|
+| aws | n/a |
+
 ## Inputs ##
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-------:|:--------:|
-| assume_any_role_anywhere_policy_description | The description to associate with the IAM policy that allows assumption of any role in any account, so long as it has a trust relationship with the Users account. | string | `Allow assumption of any role in any account, so long as it has a trust relationship with the Users account.` | no |
-| assume_any_role_anywhere_policy_name | The name to assign the IAM policy that allows assumption of any role in any account, so long as it has a trust relationship with the Users account. | string | `AssumeAnyRoleAnywhere` | no |
-| aws_region | The AWS region where the non-global resources for this account are to be provisioned (e.g. us-east-1) | string | `us-east-1` | no |
-| godlike_usernames | The usernames associated with the god-like accounts to be created, which are allowed to access the terraform backend, are IAM administrators for the Users account, and are allowed to assume any role that has a trust relationship with the Users account.  The format first.last is recommended.  Example: ["firstname1.lastname1", "firstname2.lastname2"] | list(string) | | yes |
-| gods_group_name | The name of the group to be created for the god-like users that are allowed to access the terraform backend, are IAM administrators for the Users account, and are allowed to assume any role that has a trust relationship with the Users account. | string | `gods` | no |
-| provisionaccount_role_description | The description to associate with the IAM role that allows access to provision all AWS resources in the Users account | string | `Allows sufficient access to provision all AWS resources in the Users account.` | no |
-| provisionaccount_role_name | The name to assign the IAM role that allows sufficient permissions to provision all AWS resources in the Users account. | string | `ProvisionAccount` | no |
-| tags | Tags to apply to all AWS resources provisioned. | map(string) | `{}` | no |
+|------|-------------|------|---------|:--------:|
+| assume_any_role_anywhere_policy_description | The description to associate with the IAM policy that allows assumption of any role in any account, so long as it has a trust relationship with the Users account. | `string` | `Allow assumption of any role in any account, so long as it has a trust relationship with the Users account.` | no |
+| assume_any_role_anywhere_policy_name | The name to assign the IAM policy that allows assumption of any role in any account, so long as it has a trust relationship with the Users account. | `string` | `AssumeAnyRoleAnywhere` | no |
+| aws_region | The AWS region where the non-global resources for this account are to be provisioned (e.g. "us-east-1"). | `string` | `us-east-1` | no |
+| godlike_usernames | The usernames associated with the god-like accounts to be created, which are allowed to access the terraform backend, are IAM administrators for the Users account, and are allowed to assume any role that has a trust relationship with the Users account.  The format first.last is recommended.  Example: ["firstname1.lastname1",  "firstname2.lastname2"] | `list(string)` | n/a | yes |
+| gods_group_name | The name of the group to be created for the god-like users that are allowed to access the terraform backend, are IAM administrators for the Users account, and are allowed to assume any role that has a trust relationship with the Users account. | `string` | `gods` | no |
+| provisionaccount_role_description | The description to associate with the IAM role that allows access to provision all AWS resources in the Users account. | `string` | `Allows sufficient access to provision all AWS resources in the Users account.` | no |
+| provisionaccount_role_name | The name to assign the IAM role that allows sufficient permissions to provision all AWS resources in the Users account. | `string` | `ProvisionAccount` | no |
+| tags | Tags to apply to all AWS resources provisioned. | `map(string)` | `{}` | no |
 
 ## Outputs ##
 


### PR DESCRIPTION
## 🗣 Description

This pull request adds an IAM role that allows dev users to create an SSM Session Manager session to any EC2 instance in this account.

## 💭 Motivation and Context

We are moving to using SSM Session Manager instead of using direct `ssh`.  See cisagov/cool-assessment-terraform#46 for more details as to why.

## 🧪 Testing

I have applied these changes to both production and staging.  I have verified in staging that they perform as expected.

## 🚥 Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
