### PR TITLE
Move to version 3.X of the Terraform AWS provider

### DIFF
--- a/audit/README.md
+++ b/audit/README.md
@@ -60,13 +60,11 @@ future changes by simply running `terraform apply
 | Name | Version |
 |------|---------|
 | terraform | ~> 0.12.0 |
-| aws | ~> 2.0 |
+| aws | ~> 3.0 |
 
 ## Providers ##
 
-| Name | Version |
-|------|---------|
-| aws | ~> 2.0 |
+No provider.
 
 ## Inputs ##
 

--- a/audit/versions.tf
+++ b/audit/versions.tf
@@ -6,6 +6,6 @@ terraform {
   # major version currently being used.  This practice will help us
   # avoid unwelcome surprises.
   required_providers {
-    aws = "~> 2.0"
+    aws = "~> 3.0"
   }
 }

--- a/dns/README.md
+++ b/dns/README.md
@@ -60,13 +60,13 @@ future changes by simply running `terraform apply
 | Name | Version |
 |------|---------|
 | terraform | ~> 0.12.0 |
-| aws | ~> 2.0 |
+| aws | ~> 3.0 |
 
 ## Providers ##
 
 | Name | Version |
 |------|---------|
-| aws | ~> 2.0 |
+| aws | ~> 3.0 |
 
 ## Inputs ##
 

--- a/dns/versions.tf
+++ b/dns/versions.tf
@@ -6,6 +6,6 @@ terraform {
   # major version currently being used.  This practice will help us
   # avoid unwelcome surprises.
   required_providers {
-    aws = "~> 2.0"
+    aws = "~> 3.0"
   }
 }

--- a/dynamic/README.md
+++ b/dynamic/README.md
@@ -62,13 +62,11 @@ future changes by simply running `terraform apply
 | Name | Version |
 |------|---------|
 | terraform | ~> 0.12.0 |
-| aws | ~> 2.0 |
+| aws | ~> 3.0 |
 
 ## Providers ##
 
-| Name | Version |
-|------|---------|
-| aws | ~> 2.0 |
+No provider.
 
 ## Inputs ##
 

--- a/dynamic/versions.tf
+++ b/dynamic/versions.tf
@@ -6,6 +6,6 @@ terraform {
   # major version currently being used.  This practice will help us
   # avoid unwelcome surprises.
   required_providers {
-    aws = "~> 2.0"
+    aws = "~> 3.0"
   }
 }

--- a/images/README.md
+++ b/images/README.md
@@ -65,14 +65,14 @@ future changes by simply running `terraform apply
 | Name | Version |
 |------|---------|
 | terraform | ~> 0.12.0 |
-| aws | ~> 2.0 |
+| aws | ~> 3.0 |
 
 ## Providers ##
 
 | Name | Version |
 |------|---------|
-| aws | ~> 2.0 |
-| aws.organizationsreadonly | ~> 2.0 |
+| aws | ~> 3.0 |
+| aws.organizationsreadonly | ~> 3.0 |
 
 ## Inputs ##
 

--- a/images/versions.tf
+++ b/images/versions.tf
@@ -6,6 +6,6 @@ terraform {
   # major version currently being used.  This practice will help us
   # avoid unwelcome surprises.
   required_providers {
-    aws = "~> 2.0"
+    aws = "~> 3.0"
   }
 }

--- a/log-archive/README.md
+++ b/log-archive/README.md
@@ -61,13 +61,11 @@ future changes by simply running `terraform apply
 | Name | Version |
 |------|---------|
 | terraform | ~> 0.12.0 |
-| aws | ~> 2.0 |
+| aws | ~> 3.0 |
 
 ## Providers ##
 
-| Name | Version |
-|------|---------|
-| aws | ~> 2.0 |
+No provider.
 
 ## Inputs ##
 

--- a/log-archive/versions.tf
+++ b/log-archive/versions.tf
@@ -6,6 +6,6 @@ terraform {
   # major version currently being used.  This practice will help us
   # avoid unwelcome surprises.
   required_providers {
-    aws = "~> 2.0"
+    aws = "~> 3.0"
   }
 }

--- a/master/README.md
+++ b/master/README.md
@@ -60,13 +60,13 @@ future changes by simply running `terraform apply
 | Name | Version |
 |------|---------|
 | terraform | ~> 0.12.0 |
-| aws | ~> 2.0 |
+| aws | ~> 3.0 |
 
 ## Providers ##
 
 | Name | Version |
 |------|---------|
-| aws | ~> 2.0 |
+| aws | ~> 3.0 |
 
 ## Inputs ##
 

--- a/master/versions.tf
+++ b/master/versions.tf
@@ -6,6 +6,6 @@ terraform {
   # major version currently being used.  This practice will help us
   # avoid unwelcome surprises.
   required_providers {
-    aws = "~> 2.0"
+    aws = "~> 3.0"
   }
 }

--- a/provisionaccount-role-tf-module/README.md
+++ b/provisionaccount-role-tf-module/README.md
@@ -36,13 +36,13 @@ module "provisionaccount" {
 | Name | Version |
 |------|---------|
 | terraform | ~> 0.12.0 |
-| aws | ~> 2.0 |
+| aws | ~> 3.0 |
 
 ## Providers ##
 
 | Name | Version |
 |------|---------|
-| aws | ~> 2.0 |
+| aws | ~> 3.0 |
 
 ## Inputs ##
 

--- a/provisionaccount-role-tf-module/examples/basic_usage/README.md
+++ b/provisionaccount-role-tf-module/examples/basic_usage/README.md
@@ -60,7 +60,8 @@ future changes by simply running `terraform apply
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12 |
+| terraform | ~> 0.12.0 |
+| aws | ~> 3.0 |
 
 ## Providers ##
 

--- a/provisionaccount-role-tf-module/examples/basic_usage/versions.tf
+++ b/provisionaccount-role-tf-module/examples/basic_usage/versions.tf
@@ -6,6 +6,6 @@ terraform {
   # major version currently being used.  This practice will help us
   # avoid unwelcome surprises.
   required_providers {
-    aws = "~> 2.0"
+    aws = "~> 3.0"
   }
 }

--- a/provisionaccount-role-tf-module/versions.tf
+++ b/provisionaccount-role-tf-module/versions.tf
@@ -6,6 +6,6 @@ terraform {
   # major version currently being used.  This practice will help us
   # avoid unwelcome surprises.
   required_providers {
-    aws = "~> 2.0"
+    aws = "~> 3.0"
   }
 }

--- a/shared-services/README.md
+++ b/shared-services/README.md
@@ -61,13 +61,13 @@ future changes by simply running `terraform apply
 | Name | Version |
 |------|---------|
 | terraform | ~> 0.12.0 |
-| aws | ~> 2.0 |
+| aws | ~> 3.0 |
 
 ## Providers ##
 
 | Name | Version |
 |------|---------|
-| aws | ~> 2.0 |
+| aws | ~> 3.0 |
 
 ## Inputs ##
 

--- a/shared-services/versions.tf
+++ b/shared-services/versions.tf
@@ -6,6 +6,6 @@ terraform {
   # major version currently being used.  This practice will help us
   # avoid unwelcome surprises.
   required_providers {
-    aws = "~> 2.0"
+    aws = "~> 3.0"
   }
 }

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -90,13 +90,13 @@ future changes by simply running `terraform apply
 | Name | Version |
 |------|---------|
 | terraform | ~> 0.12.0 |
-| aws | ~> 2.0 |
+| aws | ~> 3.0 |
 
 ## Providers ##
 
 | Name | Version |
 |------|---------|
-| aws | ~> 2.0 |
+| aws | ~> 3.0 |
 
 ## Inputs ##
 

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -6,6 +6,6 @@ terraform {
   # major version currently being used.  This practice will help us
   # avoid unwelcome surprises.
   required_providers {
-    aws = "~> 2.0"
+    aws = "~> 3.0"
   }
 }

--- a/users/README.md
+++ b/users/README.md
@@ -65,13 +65,13 @@ future changes by simply running `terraform apply
 | Name | Version |
 |------|---------|
 | terraform | ~> 0.12.0 |
-| aws | ~> 2.0 |
+| aws | ~> 3.0 |
 
 ## Providers ##
 
 | Name | Version |
 |------|---------|
-| aws | ~> 2.0 |
+| aws | ~> 3.0 |
 
 ## Inputs ##
 

--- a/users/versions.tf
+++ b/users/versions.tf
@@ -6,6 +6,6 @@ terraform {
   # major version currently being used.  This practice will help us
   # avoid unwelcome surprises.
   required_providers {
-    aws = "~> 2.0"
+    aws = "~> 3.0"
   }
 }


### PR DESCRIPTION
## 🗣 Description

In this pull request I update the Terraform code to use version 3.X of the Terraform AWS provider.

## 💭 Motivation and Context

Version 3.X of the Terraform AWS provider has been out for a while and has stabilized.  We don't want to get left behind.

## 🧪 Testing

All pre-commit hooks pass.

## 🚥 Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)
- [x] Update Terraform provider

## ✅ Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
