### PR TITLE
Enable PCA-only Terraform backend access

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -102,9 +102,12 @@ future changes by simply running `terraform apply
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| access_pca_terraform_backend_role_description | The description to associate with the IAM role (as well as the corresponding policy) that allows sufficient access to the PCA-related items in the Terraform S3 bucket and DynamoDB table to use those resources as a Terraform backend. | `string` | `Allows sufficient access to the PCA-related items in the Terraform S3 bucket and DynamoDB table to use those resources as a Terraform backend.` | no |
+| access_pca_terraform_backend_role_name | The name to assign the IAM role (as well as the corresponding policy) that allows sufficient access to the PCA-related items in the Terraform S3 bucket and DynamoDB table to use those resources as a Terraform backend. | `string` | `AccessPCATerraformBackend` | no |
 | access_terraform_backend_role_description | The description to associate with the IAM role (as well as the corresponding policy) that allows sufficient access to the Terraform S3 bucket and DynamoDB table to use those resources as a Terraform backend. | `string` | `Allows sufficient access to the Terraform S3 bucket and DynamoDB table to use those resources as a Terraform backend.` | no |
 | access_terraform_backend_role_name | The name to assign the IAM role (as well as the corresponding policy) that allows sufficient access to the Terraform S3 bucket and DynamoDB table to use those resources as a Terraform backend. | `string` | `AccessTerraformBackend` | no |
 | aws_region | The AWS region where the non-global resources for this account are to be provisioned (e.g. "us-east-1"). | `string` | `us-east-1` | no |
+| pca_terraform_projects | The list of project names that contain PCA-related Terraform code (e.g. ["my-pca-project"]). | `list(string)` | `[]` | no |
 | provisionaccount_role_description | The description to associate with the IAM role that allows sufficient permissions to provision all AWS resources in the Terraform account. | `string` | `Allows sufficient permissions to provision all AWS resources in the Terraform account.` | no |
 | provisionaccount_role_name | The name to assign the IAM role that allows sufficient permissions to provision all AWS resources in the Terraform account. | `string` | `ProvisionAccount` | no |
 | provisionbackend_policy_description | The description to associate with the IAM policy that allows sufficient permissions to provision the Terraform backend resources in the Terraform account. | `string` | `Allows sufficient permissions to provision the Terraform backend resources in the Terraform account.` | no |
@@ -122,6 +125,7 @@ future changes by simply running `terraform apply
 
 | Name | Description |
 |------|-------------|
+| access_pca_terraform_backend_role | The IAM role that allows sufficient access to the the PCA-related items in the Terraform S3 bucket and DynamoDB table to use those resources as a Terraform backend. |
 | access_terraform_backend_role | The IAM role that allows sufficient access to the Terraform S3 bucket and DynamoDB table to use those resources as a Terraform backend. |
 | provisionaccount_role | The IAM role that allows sufficient permissions to provision all AWS resources in the Terraform account. |
 | read_terraform_state_role | The IAM role that allows read-only access to the S3 bucket where Terraform state is stored. |

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -63,13 +63,9 @@ To do this, follow these steps:
 1. Create a `<workspace_name>.tfvars` file with all of the required
    variables (see [Inputs](#Inputs) below for details):
 
-   ```console
+   ```hcl
+   state_bucket_name = "my-terraform-state-bucket"
    users_account_id = "222222222222"
-
-   admin_usernames = [
-     "first.last",
-     "first2.last2"
-   ]
    ```
 
 1. Run the command `terraform init`.

--- a/terraform/access_pca_backend_policy.tf
+++ b/terraform/access_pca_backend_policy.tf
@@ -1,0 +1,46 @@
+# ------------------------------------------------------------------------------
+# Create the IAM policy that allows sufficient access to PCA-related S3 and
+# DynamoDB resources to use them for a Terraform backend.  Note that this
+# policy does NOT allow access to non-PCA S3 and DynamoDB resources.
+# ------------------------------------------------------------------------------
+
+# IAM policy document that allows sufficient access to the state
+# bucket and state locking table to use those resources as a Terraform
+# backend for PCA projects.
+data "aws_iam_policy_document" "access_pca_terraform_backend_access_doc" {
+  statement {
+    actions = [
+      "s3:ListBucket",
+    ]
+    resources = [
+      aws_s3_bucket.state_bucket.arn,
+    ]
+  }
+
+  statement {
+    actions = [
+      "s3:DeleteObject",
+      "s3:GetObject",
+      "s3:PutObject",
+    ]
+    # Any workspace of any project in var.pca_terraform_projects
+    resources = [for tf_project in var.pca_terraform_projects : format("%s/env:/*/%s/*", aws_s3_bucket.state_bucket.arn, tf_project)]
+  }
+
+  statement {
+    actions = [
+      "dynamodb:DeleteItem",
+      "dynamodb:GetItem",
+      "dynamodb:PutItem",
+    ]
+    # Any workspace of any project in var.pca_terraform_projects
+    resources = [for tf_project in var.pca_terraform_projects : format("%s/env:/*/%s/*", aws_dynamodb_table.state_lock_table.arn, tf_project)]
+  }
+}
+
+# The IAM policy for PCA Terraform access
+resource "aws_iam_policy" "access_pca_terraform_backend_access_policy" {
+  description = var.access_pca_terraform_backend_role_description
+  name        = var.access_pca_terraform_backend_role_name
+  policy      = data.aws_iam_policy_document.access_pca_terraform_backend_access_doc.json
+}

--- a/terraform/access_pca_backend_policy.tf
+++ b/terraform/access_pca_backend_policy.tf
@@ -33,8 +33,9 @@ data "aws_iam_policy_document" "access_pca_terraform_backend_access_doc" {
       "dynamodb:GetItem",
       "dynamodb:PutItem",
     ]
-    # Any workspace of any project in var.pca_terraform_projects
-    resources = [for tf_project in var.pca_terraform_projects : format("%s/env:/*/%s/*", aws_dynamodb_table.state_lock_table.arn, tf_project)]
+    resources = [
+      "${aws_dynamodb_table.state_lock_table.arn}",
+    ]
   }
 }
 

--- a/terraform/access_pca_backend_role.tf
+++ b/terraform/access_pca_backend_role.tf
@@ -1,0 +1,18 @@
+# ------------------------------------------------------------------------------
+# Create the IAM role that allows sufficient access to PCA-related S3 and
+# DynamoDB resources to use them for a Terraform backend.  Note that this
+# role does NOT allow access to non-PCA S3 and DynamoDB resources.
+# ------------------------------------------------------------------------------
+
+resource "aws_iam_role" "access_pca_terraform_backend_role" {
+  assume_role_policy = data.aws_iam_policy_document.assume_role_doc.json
+  description        = var.access_pca_terraform_backend_role_description
+  name               = var.access_pca_terraform_backend_role_name
+  tags               = var.tags
+}
+
+# Attach the IAM policy to the role
+resource "aws_iam_role_policy_attachment" "access_pca_terraform_backend_policy_attachment" {
+  policy_arn = aws_iam_policy.access_pca_terraform_backend_access_policy.arn
+  role       = aws_iam_role.access_pca_terraform_backend_role.name
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -3,6 +3,11 @@ output "access_terraform_backend_role" {
   description = "The IAM role that allows sufficient access to the Terraform S3 bucket and DynamoDB table to use those resources as a Terraform backend."
 }
 
+output "access_pca_terraform_backend_role" {
+  value       = aws_iam_role.access_pca_terraform_backend_role
+  description = "The IAM role that allows sufficient access to the the PCA-related items in the Terraform S3 bucket and DynamoDB table to use those resources as a Terraform backend."
+}
+
 output "provisionaccount_role" {
   value       = module.provisionaccount.provisionaccount_role
   description = "The IAM role that allows sufficient permissions to provision all AWS resources in the Terraform account."

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -20,6 +20,18 @@ variable "users_account_id" {
 # These parameters have reasonable defaults.
 # ------------------------------------------------------------------------------
 
+variable "access_pca_terraform_backend_role_description" {
+  type        = string
+  description = "The description to associate with the IAM role (as well as the corresponding policy) that allows sufficient access to the PCA-related items in the Terraform S3 bucket and DynamoDB table to use those resources as a Terraform backend."
+  default     = "Allows sufficient access to the PCA-related items in the Terraform S3 bucket and DynamoDB table to use those resources as a Terraform backend."
+}
+
+variable "access_pca_terraform_backend_role_name" {
+  type        = string
+  description = "The name to assign the IAM role (as well as the corresponding policy) that allows sufficient access to the PCA-related items in the Terraform S3 bucket and DynamoDB table to use those resources as a Terraform backend."
+  default     = "AccessPCATerraformBackend"
+}
+
 variable "access_terraform_backend_role_description" {
   type        = string
   description = "The description to associate with the IAM role (as well as the corresponding policy) that allows sufficient access to the Terraform S3 bucket and DynamoDB table to use those resources as a Terraform backend."
@@ -36,6 +48,12 @@ variable "aws_region" {
   type        = string
   description = "The AWS region where the non-global resources for this account are to be provisioned (e.g. \"us-east-1\")."
   default     = "us-east-1"
+}
+
+variable "pca_terraform_projects" {
+  type        = list(string)
+  description = "The list of project names that contain PCA-related Terraform code (e.g. [\"my-pca-project\"])."
+  default     = []
 }
 
 variable "provisionaccount_role_description" {


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##
This PR adds a role and policy that allows read/write access to PCA-related Terraform state resources (S3 and DynamoDB).

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and Context ##
This access is needed so that users who will be Terraforming PCA-related projects can store their state in AWS without being given access to non-PCA Terraform state resources.

This PR is part of the work needed for https://github.com/cisagov/cool-system/issues/82.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##
I tested this by applying the changes to our Production environment and verifying that the new role and policy were created correctly.  The true test will come when we confirm that our PCA Terraform users are able to successfully use our AWS S3/DynamoDB backend.

All pre-commit hooks pass.

<!-- How did you test your changes? How could someone else test this PR? -->

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
* [x] All new and existing tests pass.
