### PR TITLE
Add a missing permission

### DIFF
--- a/images/provisionec2amicreateroles_policy.tf
+++ b/images/provisionec2amicreateroles_policy.tf
@@ -15,6 +15,7 @@ data "aws_iam_policy_document" "provisionec2amicreateroles_doc" {
       "iam:GetRolePolicy",
       "iam:ListAttachedRolePolicies",
       "iam:ListInstanceProfilesForRole",
+      "iam:ListRolePolicies",
       "iam:PutRolePolicy",
       "iam:TagRole",
       "iam:UpdateRole"


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds a necessary, but previously missing, permission to a policy.

## 💭 Motivation and context ##

Sometimes when I am creating EC2 AMI build users for `packer` repos my `terraform apply` command fails because I am missing this permission.

## 🧪 Testing ##

This change has been applied to both the production and staging "Images" accounts and I have not seen that particular error since.

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
