### PR TITLE
Add a missing permission to allow tagging of policy resources

### DIFF
--- a/images/provisionthirdpartybucketreadroles_policy.tf
+++ b/images/provisionthirdpartybucketreadroles_policy.tf
@@ -36,7 +36,8 @@ data "aws_iam_policy_document" "provisionthirdpartybucketreadroles" {
       "iam:DeletePolicyVersion",
       "iam:GetPolicy",
       "iam:GetPolicyVersion",
-      "iam:ListPolicyVersions"
+      "iam:ListPolicyVersions",
+      "iam:TagPolicy",
     ]
     resources = [
       "arn:aws:iam::${data.aws_caller_identity.images.account_id}:policy/ThirdPartyBucketRead-*"


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds a missing permission to allow the tagging of policy resources.

## 💭 Motivation and context ##

I realized this change was required while attempting to apply the changes in cisagov/ansible-role-cobalt-strike#35 while including the changes from cisagov/s3-read-role-tf-module#15.

## 🧪 Testing ##

I applied these changes to our staging and production COOL environments and verified that I was able to apply the changes in cisagov/ansible-role-cobalt-strike#35 while including the changes from cisagov/s3-read-role-tf-module#15.

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
* [x] All new and existing tests pass.
