### PR TITLE
Give Terraform instances access to two roles

### DIFF
--- a/images/ami_kms_key.tf
+++ b/images/ami_kms_key.tf
@@ -113,9 +113,11 @@ data "aws_iam_policy_document" "ami_kms_doc" {
       test     = "StringLike"
       variable = "aws:PrincipalArn"
       # The ProvisionAccount role ARNs for the env* accounts, the
-      # playground, and the Shared Services account.  Any accounts
-      # that need to launch EC2 instances from AMIs encrypted using
-      # our key should be listed here.
+      # playground, and the Shared Services account, as well as the
+      # Terraformer role ARNs for the env* accounts.
+      #
+      # Any other accounts that need to launch EC2 instances from AMIs
+      # encrypted using our key should also be listed here.
       values = concat([
         for account in data.aws_organizations_organization.cool.accounts :
         "arn:aws:iam::${account.id}:role/ProvisionAccount"

--- a/images/ami_kms_key.tf
+++ b/images/ami_kms_key.tf
@@ -116,11 +116,15 @@ data "aws_iam_policy_document" "ami_kms_doc" {
       # playground, and the Shared Services account.  Any accounts
       # that need to launch EC2 instances from AMIs encrypted using
       # our key should be listed here.
-      values = [
+      values = concat([
         for account in data.aws_organizations_organization.cool.accounts :
         "arn:aws:iam::${account.id}:role/ProvisionAccount"
         if length(regexall("^env[0-9]* \\(${local.this_account_type}\\)$|^Playground Legacy \\(${local.this_account_type}\\)$|^Shared Services \\(${local.this_account_type}\\)$", account.name)) > 0
-      ]
+        ], [
+        for account in data.aws_organizations_organization.cool.accounts :
+        "arn:aws:iam::${account.id}:role/Terraformer"
+        if length(regexall("^env[0-9]* \\(${local.this_account_type}\\)$", account.name)) > 0
+      ])
     }
   }
 }

--- a/master/README.md
+++ b/master/README.md
@@ -80,7 +80,9 @@ future changes by simply running `terraform apply
 |------|------|
 | [aws_iam_role.organizationsreadonly_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.organizationsreadonly_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.read_organization](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_policy_document.assume_role_doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_organizations_organization.cool](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/organizations_organization) | data source |
 
 ## Inputs ##
 
@@ -92,7 +94,6 @@ future changes by simply running `terraform apply
 | provisionaccount\_role\_description | The description to associate with the IAM role that allows sufficient permissions to provision all AWS resources in the Master account. | `string` | `"Allows sufficient permissions to provision all AWS resources in the Master account."` | no |
 | provisionaccount\_role\_name | The name to assign the IAM role that allows sufficient permissions to provision all AWS resources in the Master account. | `string` | `"ProvisionAccount"` | no |
 | tags | Tags to apply to all AWS resources created. | `map(string)` | `{}` | no |
-| users\_account\_id | The ID of the users account.  This account will be allowed to assume the role that allows sufficient permissions to provision all AWS resources in the Master account. | `string` | n/a | yes |
 
 ## Outputs ##
 

--- a/master/assume_role_policy_doc.tf
+++ b/master/assume_role_policy_doc.tf
@@ -11,9 +11,9 @@ data "aws_iam_policy_document" "assume_role_doc" {
 
     principals {
       type = "AWS"
-      identifiers = [
-        "arn:aws:iam::${var.users_account_id}:root",
-      ]
+      # Delegate access to this role to the Users account and all
+      # assessment accounts.
+      identifiers = concat([local.users_account_id], local.assessment_account_ids)
     }
   }
 }

--- a/master/locals.tf
+++ b/master/locals.tf
@@ -15,4 +15,10 @@ locals {
     account.id
     if length(regexall("^env\\d+", account.name)) > 0
   ]
+
+  # Find the Users account by name and email
+  users_account_id = [
+    for account in data.aws_organizations_organization.cool.accounts :
+    account.id if account.name == "Users" && length(regexall("2020", account.email)) > 0
+  ][0]
 }

--- a/master/locals.tf
+++ b/master/locals.tf
@@ -1,0 +1,18 @@
+# ------------------------------------------------------------------------------
+# Retrieve the information for all accouts in the organization.  This is used
+# to lookup the account IDs for all assessment accounts.
+# ------------------------------------------------------------------------------
+data "aws_organizations_organization" "cool" {
+}
+
+# ------------------------------------------------------------------------------
+# Evaluate expressions for use throughout this configuration.
+# ------------------------------------------------------------------------------
+locals {
+  # Look up all assessment account IDs from AWS organizations provider
+  assessment_account_ids = [
+    for account in data.aws_organizations_organization.cool.accounts :
+    account.id
+    if length(regexall("^env\\d+", account.name)) > 0
+  ]
+}

--- a/master/locals.tf
+++ b/master/locals.tf
@@ -9,7 +9,13 @@ data "aws_organizations_organization" "cool" {
 # Evaluate expressions for use throughout this configuration.
 # ------------------------------------------------------------------------------
 locals {
-  # Look up all assessment account IDs from AWS organizations provider
+  # Look up all assessment account IDs via the AWS organizations
+  # provider.
+  #
+  # Note that this code works in our current "both staging and
+  # production in the same organization" arrangement, and it will also
+  # work in the future "staging, production, dev, etc. in separate
+  # organizations" arrangement.
   assessment_account_ids = [
     for account in data.aws_organizations_organization.cool.accounts :
     account.id

--- a/master/provisionaccount.tf
+++ b/master/provisionaccount.tf
@@ -5,3 +5,11 @@ module "provisionaccount" {
   provisionaccount_role_name        = var.provisionaccount_role_name
   users_account_id                  = var.users_account_id
 }
+
+# Attach a policy allowing this role to read organization information.
+# This is necessary since we can't use the role created in this repo
+# for this purpose since we need to do this to create that role.
+resource "aws_iam_role_policy_attachment" "read_organization" {
+  policy_arn = "arn:aws:iam::aws:policy/AWSOrganizationsReadOnlyAccess"
+  role       = module.provisionaccount.provisionaccount_role.name
+}

--- a/master/provisionaccount.tf
+++ b/master/provisionaccount.tf
@@ -3,7 +3,7 @@ module "provisionaccount" {
 
   provisionaccount_role_description = var.provisionaccount_role_description
   provisionaccount_role_name        = var.provisionaccount_role_name
-  users_account_id                  = var.users_account_id
+  users_account_id                  = local.users_account_id
 }
 
 # Attach a policy allowing this role to read organization information.

--- a/master/variables.tf
+++ b/master/variables.tf
@@ -1,15 +1,4 @@
 # ------------------------------------------------------------------------------
-# REQUIRED PARAMETERS
-#
-# You must provide a value for each of these parameters.
-# ------------------------------------------------------------------------------
-
-variable "users_account_id" {
-  type        = string
-  description = "The ID of the users account.  This account will be allowed to assume the role that allows sufficient permissions to provision all AWS resources in the Master account."
-}
-
-# ------------------------------------------------------------------------------
 # OPTIONAL PARAMETERS
 #
 # These parameters have reasonable defaults.


### PR DESCRIPTION
## 🗣 Description ##

This pull request:
* Modifies the assume role policy for the organization read-only role so that can be assumed by the Terraformer instances added in cisagov/cool-assessment-terraform#132.
* Updates the policy associated with the COOL AMI KMS key to also allow the Terraformer instances to use it for decrypting COOL AMIs.

## 💭 Motivation and context ##

Any Terraformer instances in assessment accounts require access to the organization read-only role, since they need to be able to pull down things like account IDs.  See cisagov/cool-assessment-terraform#132 for more details.

Any Terraformer instances in assessment accounts require access to the COOL AMI KMS key, since they need to be able to launch EC2 instances based on the COOL AMIs .  See cisagov/cool-assessment-terraform#132 for more details.

## 🧪 Testing ##

I successfully applied these changes, and then I successfully leveraged them in cisagov/cool-assessment-terraform#132.

## ✅ Checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.
