### PR TITLE
Add TagSession wherever we allow AssumeRole

### DIFF
--- a/images/assume_role_policy_doc.tf
+++ b/images/assume_role_policy_doc.tf
@@ -7,6 +7,7 @@ data "aws_iam_policy_document" "assume_role_doc" {
   statement {
     actions = [
       "sts:AssumeRole",
+      "sts:TagSession",
     ]
 
     principals {

--- a/master/assume_role_policy_doc.tf
+++ b/master/assume_role_policy_doc.tf
@@ -7,6 +7,7 @@ data "aws_iam_policy_document" "assume_role_doc" {
   statement {
     actions = [
       "sts:AssumeRole",
+      "sts:TagSession",
     ]
 
     principals {

--- a/shared-services/assume_role_policy_doc.tf
+++ b/shared-services/assume_role_policy_doc.tf
@@ -7,6 +7,7 @@ data "aws_iam_policy_document" "assume_role_doc" {
   statement {
     actions = [
       "sts:AssumeRole",
+      "sts:TagSession",
     ]
 
     principals {

--- a/terraform/assume_role_policy_doc.tf
+++ b/terraform/assume_role_policy_doc.tf
@@ -7,6 +7,7 @@ data "aws_iam_policy_document" "assume_role_doc" {
   statement {
     actions = [
       "sts:AssumeRole",
+      "sts:TagSession",
     ]
 
     principals {

--- a/users/gods_group.tf
+++ b/users/gods_group.tf
@@ -10,7 +10,10 @@ data "aws_iam_policy_document" "assume_any_role_anywhere_doc" {
   statement {
     effect = "Allow"
 
-    actions = ["sts:AssumeRole"]
+    actions = [
+      "sts:AssumeRole",
+      "sts:TagSession",
+    ]
 
     resources = [
       "arn:aws:iam::*:role/*"


### PR DESCRIPTION


# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR adds the `sts:TagSession` action to every IAM policy where we already allow `sts:AssumeRole`.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

If you are allowed to assume a role, you should also be allowed to tag the session.  This change is a result of https://github.com/cisagov/cool-accounts-userservices/pull/15#discussion_r729974117.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

This change was successfully applied in every deployed Terraform workspace (affected by these changes) for this repo.

<!-- How did you test your changes? How could someone else test this PR? -->

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
