### PR TITLE
Add a Security Group for Windows AMI Creation

### DIFF
--- a/images/README.md
+++ b/images/README.md
@@ -113,6 +113,9 @@ future changes by simply running `terraform apply
 | [aws_route.external_traffic_through_internet_gateway](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
 | [aws_s3_bucket.third_party](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket_public_access_block.third_party](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
+| [aws_security_group.windows_ami](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [aws_security_group_rule.windows_ami_ingress_via_rdp_over_tcp](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.windows_ami_ingress_via_rdp_over_udp](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_subnet.ami_build_public](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
 | [aws_vpc.ami_build](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc) | resource |
 | [aws_caller_identity.images](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
@@ -154,6 +157,7 @@ future changes by simply running `terraform apply
 | provisionvpcs\_policy\_name | The name to assign the IAM policy that allows sufficient permissions to provision VPCs (and related resources) in the Images account. | `string` | `"ProvisionVPCs"` | no |
 | tags | Tags to apply to all AWS resources created. | `map(string)` | `{}` | no |
 | third\_party\_bucket\_name\_prefix | The prefix to use to name the S3 bucket for storing third-party files.  The bucket will be named with this prefix plus the account type (e.g. production or staging). | `string` | `"cisa-cool-third-party"` | no |
+| windows\_ami\_sg\_name | The name to associate with the Security Group that allows access for finalizing Windows AMI configuration. | `string` | `"WindowsAMIBuild"` | no |
 
 ## Outputs ##
 

--- a/images/README.md
+++ b/images/README.md
@@ -114,8 +114,7 @@ future changes by simply running `terraform apply
 | [aws_s3_bucket.third_party](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket_public_access_block.third_party](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
 | [aws_security_group.windows_ami](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
-| [aws_security_group_rule.windows_ami_ingress_via_rdp_over_tcp](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.windows_ami_ingress_via_rdp_over_udp](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.windows_ami_ingress_via_rdp](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_subnet.ami_build_public](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
 | [aws_vpc.ami_build](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc) | resource |
 | [aws_caller_identity.images](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
@@ -157,7 +156,7 @@ future changes by simply running `terraform apply
 | provisionvpcs\_policy\_name | The name to assign the IAM policy that allows sufficient permissions to provision VPCs (and related resources) in the Images account. | `string` | `"ProvisionVPCs"` | no |
 | tags | Tags to apply to all AWS resources created. | `map(string)` | `{}` | no |
 | third\_party\_bucket\_name\_prefix | The prefix to use to name the S3 bucket for storing third-party files.  The bucket will be named with this prefix plus the account type (e.g. production or staging). | `string` | `"cisa-cool-third-party"` | no |
-| windows\_ami\_sg\_name | The name to associate with the Security Group that allows access for finalizing Windows AMI configuration. | `string` | `"WindowsAMIBuild"` | no |
+| windows\_ami\_sg\_name | The name to associate with the security group that allows access for finalizing Windows AMI configuration. | `string` | `"WindowsAMIBuild"` | no |
 
 ## Outputs ##
 

--- a/images/variables.tf
+++ b/images/variables.tf
@@ -144,6 +144,6 @@ variable "third_party_bucket_name_prefix" {
 
 variable "windows_ami_sg_name" {
   type        = string
-  description = "The name to associate with the Security Group that allows access for finalizing Windows AMI configuration."
+  description = "The name to associate with the security group that allows access for finalizing Windows AMI configuration."
   default     = "WindowsAMIBuild"
 }

--- a/images/variables.tf
+++ b/images/variables.tf
@@ -141,3 +141,9 @@ variable "third_party_bucket_name_prefix" {
   description = "The prefix to use to name the S3 bucket for storing third-party files.  The bucket will be named with this prefix plus the account type (e.g. production or staging)."
   default     = "cisa-cool-third-party"
 }
+
+variable "windows_ami_sg_name" {
+  type        = string
+  description = "The name to associate with the Security Group that allows access for finalizing Windows AMI configuration."
+  default     = "WindowsAMIBuild"
+}

--- a/images/windows_ami_sg.tf
+++ b/images/windows_ami_sg.tf
@@ -1,0 +1,32 @@
+# Security group for manually finishing AMI setup for imported Windows AMIs
+resource "aws_security_group" "windows_ami" {
+  # We include a name for convenience because this Security Group will be
+  # manually selected in the AWS console (for now).
+  name = var.windows_ami_sg_name
+
+  vpc_id = aws_vpc.ami_build.id
+
+  tags = {
+    Name = "AMI Build"
+  }
+}
+
+# Allow ingress to instances via RDP (TCP)
+resource "aws_security_group_rule" "windows_ami_ingress_via_rdp_over_tcp" {
+  security_group_id = aws_security_group.windows_ami.id
+  type              = "ingress"
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  from_port         = 3389
+  to_port           = 3389
+}
+
+# Allow ingress to instances via RDP (UDP)
+resource "aws_security_group_rule" "windows_ami_ingress_via_rdp_over_udp" {
+  security_group_id = aws_security_group.windows_ami.id
+  type              = "ingress"
+  protocol          = "udp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  from_port         = 3389
+  to_port           = 3389
+}

--- a/images/windows_ami_sg.tf
+++ b/images/windows_ami_sg.tf
@@ -11,21 +11,13 @@ resource "aws_security_group" "windows_ami" {
   }
 }
 
-# Allow ingress to instances via RDP (TCP)
-resource "aws_security_group_rule" "windows_ami_ingress_via_rdp_over_tcp" {
-  security_group_id = aws_security_group.windows_ami.id
-  type              = "ingress"
-  protocol          = "tcp"
-  cidr_blocks       = ["0.0.0.0/0"]
-  from_port         = 3389
-  to_port           = 3389
-}
+# Allow ingress to instances via RDP
+resource "aws_security_group_rule" "windows_ami_ingress_via_rdp" {
+  for_each = toset(["tcp", "udp"])
 
-# Allow ingress to instances via RDP (UDP)
-resource "aws_security_group_rule" "windows_ami_ingress_via_rdp_over_udp" {
   security_group_id = aws_security_group.windows_ami.id
   type              = "ingress"
-  protocol          = "udp"
+  protocol          = each.value
   cidr_blocks       = ["0.0.0.0/0"]
   from_port         = 3389
   to_port           = 3389

--- a/images/windows_ami_sg.tf
+++ b/images/windows_ami_sg.tf
@@ -1,6 +1,6 @@
 # Security group for manually finishing AMI setup for imported Windows AMIs
 resource "aws_security_group" "windows_ami" {
-  # We include a name for convenience because this Security Group will be
+  # We include a name for convenience because this security group will be
   # manually selected in the AWS console (for now).
   name = var.windows_ami_sg_name
 


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR adds a security group to use for the manual portion of Windows AMI creation. It allows RDP access and has a name to make it easy to reference when spinning up an instance with a VM import AMI.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Access is needed to finish the setup for Windows AMIs after the initial import from VM. This provides a static security group to use in a convenient way since this process is currently manual.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
Automated tests pass. I have applied these changes to the Staging environment and was able to use this Security Group to access an instance for configuration.
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.
