### PR TITLE
Add an SNS topic for CloudWatch alarms

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,7 +3,7 @@
 # These owners will be the default owners for everything in the
 # repo. Unless a later match takes precedence, these owners will be
 # requested for review when someone opens a pull request.
-* @dav3r @felddy @jsf9k
+* @dav3r @felddy @jsf9k @mcdonnnj
 
 # These folks own any files in the .github directory at the root of
 # the repository and any of its subdirectories.

--- a/audit/README.md
+++ b/audit/README.md
@@ -39,7 +39,7 @@ To do this, follow these steps:
    ```console
    tags = {
      Team        = "VM Fusion - Development"
-     Application = "COOL - Shared Services Account"
+     Application = "COOL - Audit Account"
      Workspace   = "staging"
    }
    ```

--- a/audit/README.md
+++ b/audit/README.md
@@ -32,16 +32,16 @@ To do this, follow these steps:
 
 1. Create a Terraform workspace (if you haven't already done so) by running
    `terraform workspace new <workspace_name>`
-1. Create a `<workspace_name>.tfvars` file with all of the required
-   variables (see [Inputs](#Inputs) below for details):
+1. Create a `<workspace_name>.tfvars` file with any optional variables
+   that you wish to override (see [Inputs](#Inputs) below for
+   details):
 
    ```console
-   users_account_id = "222222222222"
-
-   admin_usernames = [
-     "first.last",
-     "first2.last2"
-   ]
+   tags = {
+     Team        = "VM Fusion - Development"
+     Application = "COOL - Shared Services Account"
+     Workspace   = "staging"
+   }
    ```
 
 1. Run the command `terraform init`.
@@ -84,7 +84,6 @@ No resources.
 | provisionaccount\_role\_description | The description to associate with the IAM role that allows sufficient permissions to provision all AWS resources in the Audit account. | `string` | `"Allows sufficient permissions to provision all AWS resources in the Audit account."` | no |
 | provisionaccount\_role\_name | The name to assign the IAM role that allows sufficient permissions to provision all AWS resources in the Audit account. | `string` | `"ProvisionAccount"` | no |
 | tags | Tags to apply to all AWS resources created. | `map(string)` | `{}` | no |
-| users\_account\_id | The ID of the users account.  This account will be allowed to assume the role that allows sufficient permissions to provision all AWS resources in the Audit account. | `string` | n/a | yes |
 
 ## Outputs ##
 

--- a/audit/README.md
+++ b/audit/README.md
@@ -40,7 +40,7 @@ To do this, follow these steps:
    tags = {
      Team        = "VM Fusion - Development"
      Application = "COOL - Audit Account"
-     Workspace   = "staging"
+     Workspace   = "production"
    }
    ```
 

--- a/audit/README.md
+++ b/audit/README.md
@@ -64,17 +64,22 @@ future changes by simply running `terraform apply
 
 ## Providers ##
 
-No providers.
+| Name | Version |
+|------|---------|
+| aws.organizationsreadonly | ~> 3.38 |
 
 ## Modules ##
 
 | Name | Source | Version |
 |------|--------|---------|
+| cw\_alarm\_sns | github.com/cisagov/cw-alarm-sns-tf-module | n/a |
 | provisionaccount | github.com/cisagov/provisionaccount-role-tf-module | n/a |
 
 ## Resources ##
 
-No resources.
+| Name | Type |
+|------|------|
+| [aws_organizations_organization.cool](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/organizations_organization) | data source |
 
 ## Inputs ##
 
@@ -89,6 +94,7 @@ No resources.
 
 | Name | Description |
 |------|-------------|
+| cw\_alarm\_sns\_topic | The SNS topic to which a message is sent when a CloudWatch alarm is triggered. |
 | provisionaccount\_role | The IAM role that allows sufficient permissions to provision all AWS resources in the Audit account. |
 
 ## Contributing ##

--- a/audit/locals.tf
+++ b/audit/locals.tf
@@ -1,0 +1,15 @@
+# Retrieve the information for all accounts in the organization.  This
+# is used, for instance, to lookup the account ID for the Users
+# account.
+data "aws_organizations_organization" "cool" {
+  provider = aws.organizationsreadonly
+}
+
+locals {
+  # Find the Users account
+  users_account_id = [
+    for account in data.aws_organizations_organization.cool.accounts :
+    account.id
+    if account.name == "Users"
+  ][0]
+}

--- a/audit/outputs.tf
+++ b/audit/outputs.tf
@@ -1,3 +1,8 @@
+output "cw_alarm_sns_topic" {
+  value       = module.cw_alarm_sns.sns_topic
+  description = "The SNS topic to which a message is sent when a CloudWatch alarm is triggered."
+}
+
 output "provisionaccount_role" {
   value       = module.provisionaccount.provisionaccount_role
   description = "The IAM role that allows sufficient permissions to provision all AWS resources in the Audit account."

--- a/audit/providers.tf
+++ b/audit/providers.tf
@@ -12,3 +12,13 @@ provider "aws" {
   # profile = "cool-audit-account-admin"
   region = var.aws_region
 }
+
+# Read-only AWS Organizations provider
+provider "aws" {
+  alias = "organizationsreadonly"
+  default_tags {
+    tags = var.tags
+  }
+  profile = "cool-master-organizationsreadonly"
+  region  = var.aws_region
+}

--- a/audit/provisionaccount.tf
+++ b/audit/provisionaccount.tf
@@ -3,5 +3,5 @@ module "provisionaccount" {
 
   provisionaccount_role_description = var.provisionaccount_role_description
   provisionaccount_role_name        = var.provisionaccount_role_name
-  users_account_id                  = var.users_account_id
+  users_account_id                  = local.users_account_id
 }

--- a/audit/sns.tf
+++ b/audit/sns.tf
@@ -1,0 +1,12 @@
+# ------------------------------------------------------------------------------
+# Create the SNS topic that allows email to be sent for CloudWatch
+# alarms.  Subscribe the account email to the new SNS topic.
+# ------------------------------------------------------------------------------
+
+module "cw_alarm_sns" {
+  providers = {
+    aws                         = aws
+    aws.organizations_read_only = aws.organizationsreadonly
+  }
+  source = "github.com/cisagov/cw-alarm-sns-tf-module"
+}

--- a/audit/variables.tf
+++ b/audit/variables.tf
@@ -1,15 +1,4 @@
 # ------------------------------------------------------------------------------
-# REQUIRED PARAMETERS
-#
-# You must provide a value for each of these parameters.
-# ------------------------------------------------------------------------------
-
-variable "users_account_id" {
-  type        = string
-  description = "The ID of the users account.  This account will be allowed to assume the role that allows sufficient permissions to provision all AWS resources in the Audit account."
-}
-
-# ------------------------------------------------------------------------------
 # OPTIONAL PARAMETERS
 #
 # These parameters have reasonable defaults.

--- a/dns/README.md
+++ b/dns/README.md
@@ -32,16 +32,16 @@ To do this, follow these steps:
 
 1. Create a Terraform workspace (if you haven't already done so) by running
    `terraform workspace new <workspace_name>`
-1. Create a `<workspace_name>.tfvars` file with all of the required
-   variables (see [Inputs](#Inputs) below for details):
+1. Create a `<workspace_name>.tfvars` file with any optional variables
+   that you wish to override (see [Inputs](#Inputs) below for
+   details):
 
    ```console
-   users_account_id = "222222222222"
-
-   admin_usernames = [
-     "first.last",
-     "first2.last2"
-   ]
+   tags = {
+     Team        = "VM Fusion - Development"
+     Application = "COOL - DNS Account"
+     Workspace   = "production"
+   }
    ```
 
 1. Run the command `terraform init`.
@@ -93,7 +93,6 @@ future changes by simply running `terraform apply
 | provisionroute53\_role\_description | The description to associate with the IAM role (as well as the corresponding policy) that allows sufficient permissions to provision Route 53 in the DNS account. | `string` | `"Allows sufficient permissions to provision Route 53 in the DNS account."` | no |
 | provisionroute53\_role\_name | The name to assign the IAM role (as well as the corresponding policy) that allows sufficient permissions to provision Route 53 in the DNS account. | `string` | `"ProvisionRoute53"` | no |
 | tags | Tags to apply to all AWS resources created. | `map(string)` | `{}` | no |
-| users\_account\_id | The ID of the users account.  This account will be allowed to assume the role that allows sufficient permissions to provision all AWS resources in the DNS account. | `string` | n/a | yes |
 
 ## Outputs ##
 

--- a/dns/README.md
+++ b/dns/README.md
@@ -67,11 +67,13 @@ future changes by simply running `terraform apply
 | Name | Version |
 |------|---------|
 | aws | ~> 3.38 |
+| aws.organizationsreadonly | ~> 3.38 |
 
 ## Modules ##
 
 | Name | Source | Version |
 |------|--------|---------|
+| cw\_alarm\_sns | github.com/cisagov/cw-alarm-sns-tf-module | n/a |
 | provisionaccount | github.com/cisagov/provisionaccount-role-tf-module | n/a |
 
 ## Resources ##
@@ -82,6 +84,7 @@ future changes by simply running `terraform apply
 | [aws_iam_role_policy_attachment.provisionroute53_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_route53_delegation_set.primary](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_delegation_set) | resource |
 | [aws_iam_policy_document.provisionroute53_doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_organizations_organization.cool](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/organizations_organization) | data source |
 
 ## Inputs ##
 
@@ -98,6 +101,7 @@ future changes by simply running `terraform apply
 
 | Name | Description |
 |------|-------------|
+| cw\_alarm\_sns\_topic | The SNS topic to which a message is sent when a CloudWatch alarm is triggered. |
 | primary\_delegation\_set | The primary reusable delegation set that contains the authoritative name servers for all public DNS zones. |
 | provisionaccount\_role | The IAM role that allows sufficient permissions to provision all AWS resources in the DNS account. |
 

--- a/dns/locals.tf
+++ b/dns/locals.tf
@@ -1,0 +1,15 @@
+# Retrieve the information for all accounts in the organization.  This
+# is used, for instance, to lookup the account ID for the Users
+# account.
+data "aws_organizations_organization" "cool" {
+  provider = aws.organizationsreadonly
+}
+
+locals {
+  # Find the Users account
+  users_account_id = [
+    for account in data.aws_organizations_organization.cool.accounts :
+    account.id
+    if account.name == "Users"
+  ][0]
+}

--- a/dns/outputs.tf
+++ b/dns/outputs.tf
@@ -1,3 +1,8 @@
+output "cw_alarm_sns_topic" {
+  value       = module.cw_alarm_sns.sns_topic
+  description = "The SNS topic to which a message is sent when a CloudWatch alarm is triggered."
+}
+
 output "provisionaccount_role" {
   value       = module.provisionaccount.provisionaccount_role
   description = "The IAM role that allows sufficient permissions to provision all AWS resources in the DNS account."

--- a/dns/providers.tf
+++ b/dns/providers.tf
@@ -12,3 +12,13 @@ provider "aws" {
   # profile = "cool-dns-account-admin"
   region = var.aws_region
 }
+
+# Read-only AWS Organizations provider
+provider "aws" {
+  alias = "organizationsreadonly"
+  default_tags {
+    tags = var.tags
+  }
+  profile = "cool-master-organizationsreadonly"
+  region  = var.aws_region
+}

--- a/dns/provisionaccount.tf
+++ b/dns/provisionaccount.tf
@@ -3,5 +3,5 @@ module "provisionaccount" {
 
   provisionaccount_role_description = var.provisionaccount_role_description
   provisionaccount_role_name        = var.provisionaccount_role_name
-  users_account_id                  = var.users_account_id
+  users_account_id                  = local.users_account_id
 }

--- a/dns/sns.tf
+++ b/dns/sns.tf
@@ -1,0 +1,12 @@
+# ------------------------------------------------------------------------------
+# Create the SNS topic that allows email to be sent for CloudWatch
+# alarms.  Subscribe the account email to the new SNS topic.
+# ------------------------------------------------------------------------------
+
+module "cw_alarm_sns" {
+  providers = {
+    aws                         = aws
+    aws.organizations_read_only = aws.organizationsreadonly
+  }
+  source = "github.com/cisagov/cw-alarm-sns-tf-module"
+}

--- a/dns/variables.tf
+++ b/dns/variables.tf
@@ -1,15 +1,4 @@
 # ------------------------------------------------------------------------------
-# REQUIRED PARAMETERS
-#
-# You must provide a value for each of these parameters.
-# ------------------------------------------------------------------------------
-
-variable "users_account_id" {
-  type        = string
-  description = "The ID of the users account.  This account will be allowed to assume the role that allows sufficient permissions to provision all AWS resources in the DNS account."
-}
-
-# ------------------------------------------------------------------------------
 # OPTIONAL PARAMETERS
 #
 # These parameters have reasonable defaults.

--- a/dynamic/README.md
+++ b/dynamic/README.md
@@ -48,7 +48,7 @@ To do this, follow these steps:
      Application       = "COOL - env0 Staging Account"
      AssessmentAccount = "true"
      Team              = "VM Fusion - Development"
-     Workspace         = "env0-staging"
+     Workspace         = "env0-production"
    }
    ```
 

--- a/dynamic/README.md
+++ b/dynamic/README.md
@@ -45,7 +45,7 @@ To do this, follow these steps:
    dynamic_account_name = "env0"
 
    tags = {
-     Application       = "COOL - env0 Staging Account"
+     Application       = "COOL - env0 Production Account"
      AssessmentAccount = "true"
      Team              = "VM Fusion - Development"
      Workspace         = "env0-production"

--- a/dynamic/README.md
+++ b/dynamic/README.md
@@ -80,6 +80,7 @@ future changes by simply running `terraform apply
 
 | Name | Source | Version |
 |------|--------|---------|
+| cw\_alarm\_sns | github.com/cisagov/cw-alarm-sns-tf-module | n/a |
 | provisionaccount | github.com/cisagov/provisionaccount-role-tf-module | n/a |
 
 ## Resources ##
@@ -102,6 +103,7 @@ future changes by simply running `terraform apply
 
 | Name | Description |
 |------|-------------|
+| cw\_alarm\_sns\_topic | The SNS topic to which a message is sent when a CloudWatch alarm is triggered. |
 | provisionaccount\_role | The IAM role that allows sufficient permissions to provision all AWS resources in the dynamic account. |
 
 ## Contributing ##

--- a/dynamic/README.md
+++ b/dynamic/README.md
@@ -43,7 +43,13 @@ To do this, follow these steps:
 
    ```console
    dynamic_account_name = "env0"
-   users_account_id     = "222222222222"
+
+   tags = {
+     Application       = "COOL - env0 Staging Account"
+     AssessmentAccount = "true"
+     Team              = "VM Fusion - Development"
+     Workspace         = "env0-staging"
+   }
    ```
 
 1. Run the command `terraform init -upgrade=true`.
@@ -66,7 +72,9 @@ future changes by simply running `terraform apply
 
 ## Providers ##
 
-No providers.
+| Name | Version |
+|------|---------|
+| aws.organizationsreadonly | ~> 3.38 |
 
 ## Modules ##
 
@@ -76,7 +84,9 @@ No providers.
 
 ## Resources ##
 
-No resources.
+| Name | Type |
+|------|------|
+| [aws_organizations_organization.cool](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/organizations_organization) | data source |
 
 ## Inputs ##
 
@@ -87,7 +97,6 @@ No resources.
 | provisionaccount\_role\_description | The description to associate with the IAM role that allows sufficient permissions to provision all AWS resources in the dynamic account. | `string` | `"Allows sufficient permissions to provision all AWS resources in the dynamic account."` | no |
 | provisionaccount\_role\_name | The name to assign the IAM role that allows sufficient permissions to provision all AWS resources in the dynamic account. | `string` | `"ProvisionAccount"` | no |
 | tags | Tags to apply to all AWS resources created. | `map(string)` | `{}` | no |
-| users\_account\_id | The ID of the users account.  This account will be allowed to assume the role that allows sufficient permissions to provision all AWS resources in the dynamic account. | `string` | n/a | yes |
 
 ## Outputs ##
 

--- a/dynamic/locals.tf
+++ b/dynamic/locals.tf
@@ -1,0 +1,15 @@
+# Retrieve the information for all accounts in the organization.  This
+# is used, for instance, to lookup the account ID for the Users
+# account.
+data "aws_organizations_organization" "cool" {
+  provider = aws.organizationsreadonly
+}
+
+locals {
+  # Find the Users account
+  users_account_id = [
+    for account in data.aws_organizations_organization.cool.accounts :
+    account.id
+    if account.name == "Users"
+  ][0]
+}

--- a/dynamic/outputs.tf
+++ b/dynamic/outputs.tf
@@ -1,3 +1,8 @@
+output "cw_alarm_sns_topic" {
+  value       = module.cw_alarm_sns.sns_topic
+  description = "The SNS topic to which a message is sent when a CloudWatch alarm is triggered."
+}
+
 output "provisionaccount_role" {
   value       = module.provisionaccount.provisionaccount_role
   description = "The IAM role that allows sufficient permissions to provision all AWS resources in the dynamic account."

--- a/dynamic/providers.tf
+++ b/dynamic/providers.tf
@@ -12,3 +12,13 @@ provider "aws" {
   # profile = "cool-${var.dynamic_account_name}-account-admin"
   region = var.aws_region
 }
+
+# Read-only AWS Organizations provider
+provider "aws" {
+  alias = "organizationsreadonly"
+  default_tags {
+    tags = var.tags
+  }
+  profile = "cool-master-organizationsreadonly"
+  region  = var.aws_region
+}

--- a/dynamic/provisionaccount.tf
+++ b/dynamic/provisionaccount.tf
@@ -3,5 +3,5 @@ module "provisionaccount" {
 
   provisionaccount_role_description = var.provisionaccount_role_description
   provisionaccount_role_name        = var.provisionaccount_role_name
-  users_account_id                  = var.users_account_id
+  users_account_id                  = local.users_account_id
 }

--- a/dynamic/sns.tf
+++ b/dynamic/sns.tf
@@ -1,0 +1,12 @@
+# ------------------------------------------------------------------------------
+# Create the SNS topic that allows email to be sent for CloudWatch
+# alarms.  Subscribe the account email to the new SNS topic.
+# ------------------------------------------------------------------------------
+
+module "cw_alarm_sns" {
+  providers = {
+    aws                         = aws
+    aws.organizations_read_only = aws.organizationsreadonly
+  }
+  source = "github.com/cisagov/cw-alarm-sns-tf-module"
+}

--- a/dynamic/variables.tf
+++ b/dynamic/variables.tf
@@ -9,11 +9,6 @@ variable "dynamic_account_name" {
   description = "The name of the dynamic account to be provisioned."
 }
 
-variable "users_account_id" {
-  type        = string
-  description = "The ID of the users account.  This account will be allowed to assume the role that allows sufficient permissions to provision all AWS resources in the dynamic account."
-}
-
 # ------------------------------------------------------------------------------
 # OPTIONAL PARAMETERS
 #

--- a/images/README.md
+++ b/images/README.md
@@ -37,16 +37,16 @@ To do this, follow these steps:
 
 1. Create a Terraform workspace (if you haven't already done so) by running
    `terraform workspace new <workspace_name>`
-1. Create a `<workspace_name>.tfvars` file with all of the required
-   variables (see [Inputs](#Inputs) below for details):
+1. Create a `<workspace_name>.tfvars` file with any optional variables
+   that you wish to override (see [Inputs](#Inputs) below for
+   details):
 
    ```console
-   users_account_id = "222222222222"
-
-   admin_usernames = [
-     "first.last",
-     "first2.last2"
-   ]
+   tags = {
+     Team        = "VM Fusion - Development"
+     Application = "COOL - Images Account"
+     Workspace   = "staging"
+   }
    ```
 
 1. Run the command `terraform init`.
@@ -78,6 +78,7 @@ future changes by simply running `terraform apply
 
 | Name | Source | Version |
 |------|--------|---------|
+| cw\_alarm\_sns | github.com/cisagov/cw-alarm-sns-tf-module | n/a |
 | provisionaccount | github.com/cisagov/provisionaccount-role-tf-module | n/a |
 
 ## Resources ##
@@ -165,6 +166,7 @@ future changes by simply running `terraform apply
 |------|-------------|
 | administerkmskeys\_role | The IAM role that allows sufficient permissions to administer KMS keys in the Images account. |
 | ami\_kms\_key | The KMS key for encrypting AMIs in the Images account. |
+| cw\_alarm\_sns\_topic | The SNS topic to which a message is sent when a CloudWatch alarm is triggered. |
 | ec2amicreate\_role | The IAM role that allows sufficient permissions to create AMIs in the Images account. |
 | provisionaccount\_role | The IAM role that allows sufficient permissions to provision all AWS resources in the Images account. |
 | provisionec2amicreateroles\_role | The IAM role that allows sufficient permissions to provision IAM roles that can create AMIs in the Images account. |

--- a/images/README.md
+++ b/images/README.md
@@ -45,7 +45,7 @@ To do this, follow these steps:
    tags = {
      Team        = "VM Fusion - Development"
      Application = "COOL - Images Account"
-     Workspace   = "staging"
+     Workspace   = "production"
    }
    ```
 

--- a/images/locals.tf
+++ b/images/locals.tf
@@ -35,6 +35,6 @@ locals {
   # Find the Users account by name and email
   users_account_id = [
     for account in data.aws_organizations_organization.cool.accounts :
-    account.id if account.name == "Users" && length(regexall("2020", account.email)) > 0
+    account.id if account.name == "Users"
   ][0]
 }

--- a/images/outputs.tf
+++ b/images/outputs.tf
@@ -8,6 +8,11 @@ output "ami_kms_key" {
   description = "The KMS key for encrypting AMIs in the Images account."
 }
 
+output "cw_alarm_sns_topic" {
+  value       = module.cw_alarm_sns.sns_topic
+  description = "The SNS topic to which a message is sent when a CloudWatch alarm is triggered."
+}
+
 output "ec2amicreate_role" {
   value       = aws_iam_role.ec2amicreate_role
   description = "The IAM role that allows sufficient permissions to create AMIs in the Images account."

--- a/images/providers.tf
+++ b/images/providers.tf
@@ -13,6 +13,7 @@ provider "aws" {
   region = var.aws_region
 }
 
+# Read-only AWS Organizations provider
 provider "aws" {
   alias = "organizationsreadonly"
   default_tags {

--- a/images/sns.tf
+++ b/images/sns.tf
@@ -1,0 +1,12 @@
+# ------------------------------------------------------------------------------
+# Create the SNS topic that allows email to be sent for CloudWatch
+# alarms.  Subscribe the account email to the new SNS topic.
+# ------------------------------------------------------------------------------
+
+module "cw_alarm_sns" {
+  providers = {
+    aws                         = aws
+    aws.organizations_read_only = aws.organizationsreadonly
+  }
+  source = "github.com/cisagov/cw-alarm-sns-tf-module"
+}

--- a/log-archive/README.md
+++ b/log-archive/README.md
@@ -33,16 +33,16 @@ To do this, follow these steps:
 
 1. Create a Terraform workspace (if you haven't already done so) by running
    `terraform workspace new <workspace_name>`
-1. Create a `<workspace_name>.tfvars` file with all of the required
-   variables (see [Inputs](#Inputs) below for details):
+1. Create a `<workspace_name>.tfvars` file with any optional variables
+   that you wish to override (see [Inputs](#Inputs) below for
+   details):
 
    ```console
-   users_account_id = "222222222222"
-
-   admin_usernames = [
-     "first.last",
-     "first2.last2"
-   ]
+   tags = {
+     Team        = "VM Fusion - Development"
+     Application = "COOL - Log Archive Account"
+     Workspace   = "production"
+   }
    ```
 
 1. Run the command `terraform init`.
@@ -65,7 +65,9 @@ future changes by simply running `terraform apply
 
 ## Providers ##
 
-No providers.
+| Name | Version |
+|------|---------|
+| aws.organizationsreadonly | ~> 3.38 |
 
 ## Modules ##
 
@@ -75,7 +77,9 @@ No providers.
 
 ## Resources ##
 
-No resources.
+| Name | Type |
+|------|------|
+| [aws_organizations_organization.cool](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/organizations_organization) | data source |
 
 ## Inputs ##
 
@@ -85,7 +89,6 @@ No resources.
 | provisionaccount\_role\_description | The description to associate with the IAM role that allows sufficient permissions to provision all AWS resources in the Log Archive account. | `string` | `"Allows sufficient permissions to provision all AWS resources in the Log Archive account."` | no |
 | provisionaccount\_role\_name | The name to assign the IAM role that allows sufficient permissions to provision all AWS resources in the Log Archive account. | `string` | `"ProvisionAccount"` | no |
 | tags | Tags to apply to all AWS resources created. | `map(string)` | `{}` | no |
-| users\_account\_id | The ID of the users account.  This account will be allowed to assume the role that allows sufficient permissions to provision all AWS resources in the Log Archive account. | `string` | n/a | yes |
 
 ## Outputs ##
 

--- a/log-archive/README.md
+++ b/log-archive/README.md
@@ -73,6 +73,7 @@ future changes by simply running `terraform apply
 
 | Name | Source | Version |
 |------|--------|---------|
+| cw\_alarm\_sns | github.com/cisagov/cw-alarm-sns-tf-module | n/a |
 | provisionaccount | github.com/cisagov/provisionaccount-role-tf-module | n/a |
 
 ## Resources ##
@@ -94,6 +95,7 @@ future changes by simply running `terraform apply
 
 | Name | Description |
 |------|-------------|
+| cw\_alarm\_sns\_topic | The SNS topic to which a message is sent when a CloudWatch alarm is triggered. |
 | provisionaccount\_role | The IAM role that allows sufficient permissions to provision all AWS resources in the Log Archive account. |
 
 ## Contributing ##

--- a/log-archive/locals.tf
+++ b/log-archive/locals.tf
@@ -1,0 +1,15 @@
+# Retrieve the information for all accounts in the organization.  This
+# is used, for instance, to lookup the account ID for the Users
+# account.
+data "aws_organizations_organization" "cool" {
+  provider = aws.organizationsreadonly
+}
+
+locals {
+  # Find the Users account
+  users_account_id = [
+    for account in data.aws_organizations_organization.cool.accounts :
+    account.id
+    if account.name == "Users"
+  ][0]
+}

--- a/log-archive/outputs.tf
+++ b/log-archive/outputs.tf
@@ -1,3 +1,8 @@
+output "cw_alarm_sns_topic" {
+  value       = module.cw_alarm_sns.sns_topic
+  description = "The SNS topic to which a message is sent when a CloudWatch alarm is triggered."
+}
+
 output "provisionaccount_role" {
   value       = module.provisionaccount.provisionaccount_role
   description = "The IAM role that allows sufficient permissions to provision all AWS resources in the Log Archive account."

--- a/log-archive/providers.tf
+++ b/log-archive/providers.tf
@@ -12,3 +12,13 @@ provider "aws" {
   # profile = "cool-logarchive-account-admin"
   region = var.aws_region
 }
+
+# Read-only AWS Organizations provider
+provider "aws" {
+  alias = "organizationsreadonly"
+  default_tags {
+    tags = var.tags
+  }
+  profile = "cool-master-organizationsreadonly"
+  region  = var.aws_region
+}

--- a/log-archive/provisionaccount.tf
+++ b/log-archive/provisionaccount.tf
@@ -3,5 +3,5 @@ module "provisionaccount" {
 
   provisionaccount_role_description = var.provisionaccount_role_description
   provisionaccount_role_name        = var.provisionaccount_role_name
-  users_account_id                  = var.users_account_id
+  users_account_id                  = local.users_account_id
 }

--- a/log-archive/sns.tf
+++ b/log-archive/sns.tf
@@ -1,0 +1,12 @@
+# ------------------------------------------------------------------------------
+# Create the SNS topic that allows email to be sent for CloudWatch
+# alarms.  Subscribe the account email to the new SNS topic.
+# ------------------------------------------------------------------------------
+
+module "cw_alarm_sns" {
+  providers = {
+    aws                         = aws
+    aws.organizations_read_only = aws.organizationsreadonly
+  }
+  source = "github.com/cisagov/cw-alarm-sns-tf-module"
+}

--- a/log-archive/variables.tf
+++ b/log-archive/variables.tf
@@ -1,15 +1,4 @@
 # ------------------------------------------------------------------------------
-# REQUIRED PARAMETERS
-#
-# You must provide a value for each of these parameters.
-# ------------------------------------------------------------------------------
-
-variable "users_account_id" {
-  type        = string
-  description = "The ID of the users account.  This account will be allowed to assume the role that allows sufficient permissions to provision all AWS resources in the Log Archive account."
-}
-
-# ------------------------------------------------------------------------------
 # OPTIONAL PARAMETERS
 #
 # These parameters have reasonable defaults.

--- a/master/README.md
+++ b/master/README.md
@@ -32,16 +32,16 @@ To do this, follow these steps:
 
 1. Create a Terraform workspace (if you haven't already done so) by running
    `terraform workspace new <workspace_name>`
-1. Create a `<workspace_name>.tfvars` file with all of the required
-   variables (see [Inputs](#Inputs) below for details):
+1. Create a `<workspace_name>.tfvars` file with any optional variables
+   that you wish to override (see [Inputs](#Inputs) below for
+   details):
 
    ```console
-   users_account_id = "222222222222"
-
-   admin_usernames = [
-     "first.last",
-     "first2.last2"
-   ]
+   tags = {
+     Team        = "VM Fusion - Development"
+     Application = "COOL - Master Account"
+     Workspace   = "production"
+   }
    ```
 
 1. Run the command `terraform init`.
@@ -72,6 +72,7 @@ future changes by simply running `terraform apply
 
 | Name | Source | Version |
 |------|--------|---------|
+| cw\_alarm\_sns | github.com/cisagov/cw-alarm-sns-tf-module | n/a |
 | provisionaccount | github.com/cisagov/provisionaccount-role-tf-module | n/a |
 
 ## Resources ##
@@ -94,6 +95,7 @@ future changes by simply running `terraform apply
 | [aws_iam_policy_document.administersso_policy_doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.assume_role_doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.assume_role_users_control_tower_doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.assume_role_users_doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_organizations_organization.cool](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/organizations_organization) | data source |
 
 ## Inputs ##
@@ -117,6 +119,7 @@ future changes by simply running `terraform apply
 |------|-------------|
 | administersso\_role | The IAM role that allows sufficient permissions to administer the Single Sign-On resources required in the Master account. |
 | controltoweradmin\_role | The IAM role that allows all necessary permissions to provision AWS accounts via Control Tower in the Master account. |
+| cw\_alarm\_sns\_topic | The SNS topic to which a message is sent when a CloudWatch alarm is triggered. |
 | organizationsreadonly\_role | The IAM role that allows read-only access to all AWS Organizations information in the Master account. |
 | provisionaccount\_role | The IAM role that allows sufficient permissions to provision all AWS resources in the Master account. |
 

--- a/master/locals.tf
+++ b/master/locals.tf
@@ -26,6 +26,6 @@ locals {
   # Find the Users account by name and email
   users_account_id = [
     for account in data.aws_organizations_organization.cool.accounts :
-    account.id if account.name == "Users" && length(regexall("2020", account.email)) > 0
+    account.id if account.name == "Users"
   ][0]
 }

--- a/master/outputs.tf
+++ b/master/outputs.tf
@@ -8,6 +8,11 @@ output "controltoweradmin_role" {
   description = "The IAM role that allows all necessary permissions to provision AWS accounts via Control Tower in the Master account."
 }
 
+output "cw_alarm_sns_topic" {
+  value       = module.cw_alarm_sns.sns_topic
+  description = "The SNS topic to which a message is sent when a CloudWatch alarm is triggered."
+}
+
 output "organizationsreadonly_role" {
   value       = aws_iam_role.organizationsreadonly_role
   description = "The IAM role that allows read-only access to all AWS Organizations information in the Master account."

--- a/master/sns.tf
+++ b/master/sns.tf
@@ -1,0 +1,12 @@
+# ------------------------------------------------------------------------------
+# Create the SNS topic that allows email to be sent for CloudWatch
+# alarms.  Subscribe the account email to the new SNS topic.
+# ------------------------------------------------------------------------------
+
+module "cw_alarm_sns" {
+  providers = {
+    aws                         = aws
+    aws.organizations_read_only = aws
+  }
+  source = "github.com/cisagov/cw-alarm-sns-tf-module"
+}

--- a/shared-services/README.md
+++ b/shared-services/README.md
@@ -41,7 +41,7 @@ To do this, follow these steps:
    tags = {
      Team        = "VM Fusion - Development"
      Application = "COOL - Shared Services Account"
-     Workspace   = "staging"
+     Workspace   = "production"
    }
    ```
 

--- a/shared-services/README.md
+++ b/shared-services/README.md
@@ -33,16 +33,16 @@ To do this, follow these steps:
 
 1. Create a Terraform workspace (if you haven't already done so) by running
    `terraform workspace new <workspace_name>`
-1. Create a `<workspace_name>.tfvars` file with all of the required
-   variables (see [Inputs](#Inputs) below for details):
+1. Create a `<workspace_name>.tfvars` file with any optional variables
+   that you wish to override (see [Inputs](#Inputs) below for
+   details):
 
    ```console
-   users_account_id = "222222222222"
-
-   admin_usernames = [
-     "first.last",
-     "first2.last2"
-   ]
+   tags = {
+     Team        = "VM Fusion - Development"
+     Application = "COOL - Shared Services Account"
+     Workspace   = "staging"
+   }
    ```
 
 1. Run the command `terraform init`.
@@ -102,7 +102,6 @@ future changes by simply running `terraform apply
 | ssmsession\_role\_description | The description to associate with the IAM role (and policy) that allows creation of SSM SessionManager sessions to any EC2 instance in this account. | `string` | `"Allows creation of SSM SessionManager sessions to any EC2 instance in this account."` | no |
 | ssmsession\_role\_name | The name to assign the IAM role (and policy) that allows creation of SSM SessionManager sessions to any EC2 instance in this account. | `string` | `"StartStopSSMSession"` | no |
 | tags | Tags to apply to all AWS resources created. | `map(string)` | `{}` | no |
-| users\_account\_id | The ID of the users account.  This account will be allowed to assume the role that allows sufficient permissions to provision all AWS resources in the Shared Services account. | `string` | n/a | yes |
 
 ## Outputs ##
 

--- a/shared-services/README.md
+++ b/shared-services/README.md
@@ -68,11 +68,13 @@ future changes by simply running `terraform apply
 | Name | Version |
 |------|---------|
 | aws | ~> 3.38 |
+| aws.organizationsreadonly | ~> 3.38 |
 
 ## Modules ##
 
 | Name | Source | Version |
 |------|--------|---------|
+| cw\_alarm\_sns | github.com/cisagov/cw-alarm-sns-tf-module | first-commits |
 | provisionaccount | github.com/cisagov/provisionaccount-role-tf-module | n/a |
 | run\_shell\_ssm\_document | gazoakley/session-manager-settings/aws | n/a |
 
@@ -89,6 +91,7 @@ future changes by simply running `terraform apply
 | [aws_iam_policy_document.assume_role_doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.provisionssmdocument_policy_doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.ssmsession_doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_organizations_organization.cool](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/organizations_organization) | data source |
 
 ## Inputs ##
 
@@ -107,6 +110,7 @@ future changes by simply running `terraform apply
 
 | Name | Description |
 |------|-------------|
+| cw\_alarm\_sns\_topic | The SNS topic to which a message is sent when a CloudWatch alarm is triggered. |
 | provisionaccount\_role | The IAM role that allows sufficient permissions to provision all AWS resources in the Shared Services account. |
 | ssmsession\_role | The IAM role that allows creation of SSM SessionManager sessions to any EC2 instance in this account. |
 

--- a/shared-services/assume_role_policy_doc.tf
+++ b/shared-services/assume_role_policy_doc.tf
@@ -13,7 +13,7 @@ data "aws_iam_policy_document" "assume_role_doc" {
     principals {
       type = "AWS"
       identifiers = [
-        var.users_account_id,
+        local.users_account_id,
       ]
     }
   }

--- a/shared-services/locals.tf
+++ b/shared-services/locals.tf
@@ -1,5 +1,5 @@
 # Retrieve the information for all accounts in the organization.  This
-# is used, for instance, to lookup the account IDs for the user
+# is used, for instance, to lookup the account ID for the Users
 # account.
 data "aws_organizations_organization" "cool" {
   provider = aws.organizationsreadonly

--- a/shared-services/locals.tf
+++ b/shared-services/locals.tf
@@ -1,0 +1,15 @@
+# Retrieve the information for all accounts in the organization.  This
+# is used, for instance, to lookup the account IDs for the user
+# account.
+data "aws_organizations_organization" "cool" {
+  provider = aws.organizationsreadonly
+}
+
+locals {
+  # Find the Users account by name and email
+  users_account_id = [
+    for account in data.aws_organizations_organization.cool.accounts :
+    account.id
+    if account.name == "Users" && length(regexall("2020", account.email)) > 0
+  ][0]
+}

--- a/shared-services/locals.tf
+++ b/shared-services/locals.tf
@@ -6,10 +6,10 @@ data "aws_organizations_organization" "cool" {
 }
 
 locals {
-  # Find the Users account by name and email
+  # Find the Users account
   users_account_id = [
     for account in data.aws_organizations_organization.cool.accounts :
     account.id
-    if account.name == "Users" && length(regexall("2020", account.email)) > 0
+    if account.name == "Users"
   ][0]
 }

--- a/shared-services/outputs.tf
+++ b/shared-services/outputs.tf
@@ -1,3 +1,8 @@
+output "cw_alarm_sns_topic" {
+  value       = module.cw_alarm_sns.sns_topic
+  description = "The SNS topic to which a message is sent when a CloudWatch alarm is triggered."
+}
+
 output "provisionaccount_role" {
   value       = module.provisionaccount.provisionaccount_role
   description = "The IAM role that allows sufficient permissions to provision all AWS resources in the Shared Services account."

--- a/shared-services/providers.tf
+++ b/shared-services/providers.tf
@@ -12,3 +12,13 @@ provider "aws" {
   # profile = "cool-sharedservices-account-admin"
   region = var.aws_region
 }
+
+# Read-only AWS Organizations provider
+provider "aws" {
+  alias = "organizationsreadonly"
+  default_tags {
+    tags = var.tags
+  }
+  profile = "cool-master-organizationsreadonly"
+  region  = var.aws_region
+}

--- a/shared-services/provisionaccount.tf
+++ b/shared-services/provisionaccount.tf
@@ -3,5 +3,5 @@ module "provisionaccount" {
 
   provisionaccount_role_description = var.provisionaccount_role_description
   provisionaccount_role_name        = var.provisionaccount_role_name
-  users_account_id                  = var.users_account_id
+  users_account_id                  = local.users_account_id
 }

--- a/shared-services/sns.tf
+++ b/shared-services/sns.tf
@@ -1,0 +1,12 @@
+# ------------------------------------------------------------------------------
+# Create the SNS topic that allows email to be sent for CloudWatch
+# alarms.  Subscribe the account email to the new SNS topic.
+# ------------------------------------------------------------------------------
+
+module "cw_alarm_sns" {
+  providers = {
+    aws                         = aws
+    aws.organizations_read_only = aws.organizationsreadonly
+  }
+  source = "github.com/cisagov/cw-alarm-sns-tf-module?ref=first-commits"
+}

--- a/shared-services/sns.tf
+++ b/shared-services/sns.tf
@@ -8,5 +8,5 @@ module "cw_alarm_sns" {
     aws                         = aws
     aws.organizations_read_only = aws.organizationsreadonly
   }
-  source = "github.com/cisagov/cw-alarm-sns-tf-module?ref=first-commits"
+  source = "github.com/cisagov/cw-alarm-sns-tf-module"
 }

--- a/shared-services/variables.tf
+++ b/shared-services/variables.tf
@@ -1,15 +1,4 @@
 # ------------------------------------------------------------------------------
-# REQUIRED PARAMETERS
-#
-# You must provide a value for each of these parameters.
-# ------------------------------------------------------------------------------
-
-variable "users_account_id" {
-  type        = string
-  description = "The ID of the users account.  This account will be allowed to assume the role that allows sufficient permissions to provision all AWS resources in the Shared Services account."
-}
-
-# ------------------------------------------------------------------------------
 # OPTIONAL PARAMETERS
 #
 # These parameters have reasonable defaults.

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -61,11 +61,16 @@ To do this, follow these steps:
 1. Create a Terraform workspace (if you haven't already done so) by running
    `terraform workspace new <workspace_name>`
 1. Create a `<workspace_name>.tfvars` file with all of the required
-   variables (see [Inputs](#Inputs) below for details):
+   variables and any optional variables that you want to override (see
+   [Inputs](#Inputs) below for details):
 
    ```hcl
    state_bucket_name = "my-terraform-state-bucket"
-   users_account_id = "222222222222"
+   tags = {
+     Team        = "VM Fusion - Development"
+     Application = "COOL - Terraform Account"
+     Workspace   = "production"
+   }
    ```
 
 1. Run the command `terraform init`.
@@ -93,6 +98,7 @@ future changes by simply running `terraform apply
 | Name | Version |
 |------|---------|
 | aws | ~> 3.38 |
+| aws.organizationsreadonly | ~> 3.38 |
 
 ## Modules ##
 
@@ -128,6 +134,7 @@ future changes by simply running `terraform apply
 | [aws_iam_policy_document.assume_role_doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.provisionbackend_doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.read_terraform_state_doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_organizations_organization.cool](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/organizations_organization) | data source |
 
 ## Inputs ##
 
@@ -153,7 +160,6 @@ future changes by simply running `terraform apply
 | state\_table\_read\_capacity | The number of read units for the DynamoDB table that will be used for Terraform state locking. | `number` | `20` | no |
 | state\_table\_write\_capacity | The number of write units for the DynamoDB table that will be used for Terraform state locking. | `number` | `20` | no |
 | tags | Tags to apply to all AWS resources created. | `map(string)` | `{}` | no |
-| users\_account\_id | The ID of the users account.  This account will be allowed to assume the role that allows sufficient access to the Terraform S3 bucket and DynamoDB table to use those resources as a Terraform backend, as well as the role that allows sufficient permissions to provision all AWS resources in the Terraform account. | `string` | n/a | yes |
 
 ## Outputs ##
 

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -104,6 +104,7 @@ future changes by simply running `terraform apply
 
 | Name | Source | Version |
 |------|--------|---------|
+| cw\_alarm\_sns | github.com/cisagov/cw-alarm-sns-tf-module | n/a |
 | provisionaccount | github.com/cisagov/provisionaccount-role-tf-module | n/a |
 
 ## Resources ##
@@ -168,6 +169,7 @@ future changes by simply running `terraform apply
 | access\_domainmanager\_terraform\_backend\_role | The IAM role that allows sufficient access to the the Domain Manager-related items in the Terraform S3 bucket and DynamoDB table to use those resources as a Terraform backend. |
 | access\_pca\_terraform\_backend\_role | The IAM role that allows sufficient access to the the PCA-related items in the Terraform S3 bucket and DynamoDB table to use those resources as a Terraform backend. |
 | access\_terraform\_backend\_role | The IAM role that allows sufficient access to the Terraform S3 bucket and DynamoDB table to use those resources as a Terraform backend. |
+| cw\_alarm\_sns\_topic | The SNS topic to which a message is sent when a CloudWatch alarm is triggered. |
 | provisionaccount\_role | The IAM role that allows sufficient permissions to provision all AWS resources in the Terraform account. |
 | read\_terraform\_state\_role | The IAM role that allows read-only access to the S3 bucket where Terraform state is stored. |
 | state\_bucket | The S3 bucket where Terraform state information will be stored. |

--- a/terraform/assume_role_policy_doc.tf
+++ b/terraform/assume_role_policy_doc.tf
@@ -13,7 +13,7 @@ data "aws_iam_policy_document" "assume_role_doc" {
     principals {
       type = "AWS"
       identifiers = [
-        "arn:aws:iam::${var.users_account_id}:root",
+        "arn:aws:iam::${local.users_account_id}:root",
       ]
     }
   }

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -1,0 +1,15 @@
+# Retrieve the information for all accounts in the organization.  This
+# is used, for instance, to lookup the account ID for the Users
+# account.
+data "aws_organizations_organization" "cool" {
+  provider = aws.organizationsreadonly
+}
+
+locals {
+  # Find the Users account
+  users_account_id = [
+    for account in data.aws_organizations_organization.cool.accounts :
+    account.id
+    if account.name == "Users"
+  ][0]
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -13,6 +13,11 @@ output "access_terraform_backend_role" {
   description = "The IAM role that allows sufficient access to the Terraform S3 bucket and DynamoDB table to use those resources as a Terraform backend."
 }
 
+output "cw_alarm_sns_topic" {
+  value       = module.cw_alarm_sns.sns_topic
+  description = "The SNS topic to which a message is sent when a CloudWatch alarm is triggered."
+}
+
 output "provisionaccount_role" {
   value       = module.provisionaccount.provisionaccount_role
   description = "The IAM role that allows sufficient permissions to provision all AWS resources in the Terraform account."

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -12,3 +12,13 @@ provider "aws" {
   # profile = "cool-terraform-account-admin"
   region = var.aws_region
 }
+
+# Read-only AWS Organizations provider
+provider "aws" {
+  alias = "organizationsreadonly"
+  default_tags {
+    tags = var.tags
+  }
+  profile = "cool-master-organizationsreadonly"
+  region  = var.aws_region
+}

--- a/terraform/provisionaccount.tf
+++ b/terraform/provisionaccount.tf
@@ -3,5 +3,5 @@ module "provisionaccount" {
 
   provisionaccount_role_description = var.provisionaccount_role_description
   provisionaccount_role_name        = var.provisionaccount_role_name
-  users_account_id                  = var.users_account_id
+  users_account_id                  = local.users_account_id
 }

--- a/terraform/sns.tf
+++ b/terraform/sns.tf
@@ -1,0 +1,12 @@
+# ------------------------------------------------------------------------------
+# Create the SNS topic that allows email to be sent for CloudWatch
+# alarms.  Subscribe the account email to the new SNS topic.
+# ------------------------------------------------------------------------------
+
+module "cw_alarm_sns" {
+  providers = {
+    aws                         = aws
+    aws.organizations_read_only = aws.organizationsreadonly
+  }
+  source = "github.com/cisagov/cw-alarm-sns-tf-module"
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -9,11 +9,6 @@ variable "state_bucket_name" {
   description = "The name to use for the S3 bucket that will store the Terraform state."
 }
 
-variable "users_account_id" {
-  type        = string
-  description = "The ID of the users account.  This account will be allowed to assume the role that allows sufficient access to the Terraform S3 bucket and DynamoDB table to use those resources as a Terraform backend, as well as the role that allows sufficient permissions to provision all AWS resources in the Terraform account."
-}
-
 # ------------------------------------------------------------------------------
 # OPTIONAL PARAMETERS
 #

--- a/users/README.md
+++ b/users/README.md
@@ -38,15 +38,19 @@ To do this, follow these steps:
 1. Create a Terraform workspace (if you haven't already done so) by running
    `terraform workspace new <workspace_name>`
 1. Create a `<workspace_name>.tfvars` file with all of the required
-   variables (see [Inputs](#Inputs) below for details).  Note that
-   `access_backend_terraform_role_arn` is the `backend_role_arn` output
-   from the bootstrapping the terraform subdirectory:
+   variables and any optional variables that you want to override (see
+   [Inputs](#Inputs) below for details):
 
    ```console
-   admin_usernames = [
-     "user.one",
-     "user.two"
+   godlike_usernames = [
+     "lemmy.kilmister",
    ]
+
+   tags = {
+     Team        = "VM Fusion - Development"
+     Application = "COOL - Users Account"
+     Workspace   = "production"
+   }
    ```
 
 1. Run the command `terraform init`.
@@ -77,6 +81,7 @@ future changes by simply running `terraform apply
 
 | Name | Source | Version |
 |------|--------|---------|
+| cw\_alarm\_sns | github.com/cisagov/cw-alarm-sns-tf-module | n/a |
 | provisionaccount | github.com/cisagov/provisionaccount-role-tf-module | n/a |
 
 ## Resources ##
@@ -118,6 +123,7 @@ future changes by simply running `terraform apply
 | Name | Description |
 |------|-------------|
 | assume\_any\_role\_anywhere\_policy | The IAM role that allows assumption of any role in any account, so long as it has a trust relationship with the Users account. |
+| cw\_alarm\_sns\_topic | The SNS topic to which a message is sent when a CloudWatch alarm is triggered. |
 | godlike\_users | The IAM users that are allowed to access the terraform backend, are IAM administrators for the Users account, and are allowed to assume any role that has a trust relationship with the Users account. |
 | gods\_group | The IAM group containing the god-like users that are allowed to access the terraform backend, are IAM administrators for the Users account, and are allowed to assume any role that has a trust relationship with the Users account. |
 | provisionaccount\_role | The IAM role that allows sufficient permissions to provision all AWS resources in this account. |

--- a/users/outputs.tf
+++ b/users/outputs.tf
@@ -3,6 +3,11 @@ output "assume_any_role_anywhere_policy" {
   description = "The IAM role that allows assumption of any role in any account, so long as it has a trust relationship with the Users account."
 }
 
+output "cw_alarm_sns_topic" {
+  value       = module.cw_alarm_sns.sns_topic
+  description = "The SNS topic to which a message is sent when a CloudWatch alarm is triggered."
+}
+
 output "godlike_users" {
   value       = aws_iam_user.gods
   description = "The IAM users that are allowed to access the terraform backend, are IAM administrators for the Users account, and are allowed to assume any role that has a trust relationship with the Users account."

--- a/users/providers.tf
+++ b/users/providers.tf
@@ -11,3 +11,13 @@ provider "aws" {
   # profile = "cool-users-account-admin"
   region = var.aws_region
 }
+
+# Read-only AWS Organizations provider
+provider "aws" {
+  alias = "organizationsreadonly"
+  default_tags {
+    tags = var.tags
+  }
+  profile = "cool-master-organizationsreadonly"
+  region  = var.aws_region
+}

--- a/users/sns.tf
+++ b/users/sns.tf
@@ -1,0 +1,12 @@
+# ------------------------------------------------------------------------------
+# Create the SNS topic that allows email to be sent for CloudWatch
+# alarms.  Subscribe the account email to the new SNS topic.
+# ------------------------------------------------------------------------------
+
+module "cw_alarm_sns" {
+  providers = {
+    aws                         = aws
+    aws.organizations_read_only = aws.organizationsreadonly
+  }
+  source = "github.com/cisagov/cw-alarm-sns-tf-module"
+}


### PR DESCRIPTION
## 🗣 Description ##

This pull request:
- Makes use of the AWS Organizations read-only provider to obtain the ID of the "Users" AWS account.  Previously the ID of the "Users" account was being passed in as an input parameter.
- Makes use of [cisagov/cw-alarm-sns-tf-module](https://github.com/cisagov/cw-alarm-sns-tf-module) to create an SNS topic that can be published to in order to send a message to the account email when a CloudWatch alarm is triggered.

## 💭 Motivation and context ##

- Passing in the ID of the "Users" account explicitly has been needing to be cleaned up for years.
- We require such an SNS topic so that we can receive emails when CloudWatch alarms indicate a potential problem with the COOL.

## 🧪 Testing ##

All automated testing passes.  This code has already been applied to:
- All non-dynamic accounts
- All dynamic staging accounts

A script is currently running to apply the changes to all dynamic production accounts.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

- [x] Revert dependencies to default branches.