### PR TITLE
Add role to provision resources related to publishing egress IPs

### DIFF
--- a/dns/README.md
+++ b/dns/README.md
@@ -80,9 +80,15 @@ future changes by simply running `terraform apply
 
 | Name | Type |
 |------|------|
+| [aws_iam_policy.provisionpublishegressip_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.provisionroute53_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_role.provisionpublishegressip_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.provisionpublishegressip_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.provisionroute53_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_route53_delegation_set.primary](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_delegation_set) | resource |
+| [aws_caller_identity.dns](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_iam_policy_document.assume_role_doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.provisionpublishegressip_doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.provisionroute53_doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_organizations_organization.cool](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/organizations_organization) | data source |
 
@@ -93,8 +99,12 @@ future changes by simply running `terraform apply
 | aws\_region | The AWS region where the non-global resources for the DNS account are to be provisioned (e.g. "us-east-1"). | `string` | `"us-east-1"` | no |
 | provisionaccount\_role\_description | The description to associate with the IAM role that allows sufficient permissions to provision all AWS resources in the DNS account. | `string` | `"Allows sufficient permissions to provision all AWS resources in the DNS account."` | no |
 | provisionaccount\_role\_name | The name to assign the IAM role that allows sufficient permissions to provision all AWS resources in the DNS account. | `string` | `"ProvisionAccount"` | no |
+| provisionpublishegressip\_role\_description | The description to associate with the IAM role (as well as the corresponding policy) that allows sufficient permissions to provision all resources related to the publish-egress-ip Lambda in the DNS account. | `string` | `"Allows sufficient permissions to provision all resources related to the publish-egress-ip Lambda in the DNS account."` | no |
+| provisionpublishegressip\_role\_name | The name to assign the IAM role (as well as the corresponding policy) that allows sufficient permissions to provision all resources related to the publish-egress-ip Lambda in the DNS account. | `string` | `"ProvisionPublishEgressIP"` | no |
 | provisionroute53\_role\_description | The description to associate with the IAM role (as well as the corresponding policy) that allows sufficient permissions to provision Route 53 in the DNS account. | `string` | `"Allows sufficient permissions to provision Route 53 in the DNS account."` | no |
 | provisionroute53\_role\_name | The name to assign the IAM role (as well as the corresponding policy) that allows sufficient permissions to provision Route 53 in the DNS account. | `string` | `"ProvisionRoute53"` | no |
+| publishegressip\_lambda\_name | The name of the Lambda function used in cisagov/publish-egress-ip-terraform.  This name is used to specify resource constraints in the role/policy specified in var.provisionpublishegressip\_role\_name. | `string` | `"publish-egress-ip"` | no |
+| publishegressip\_role\_name | The name of the IAM role (meant to be used in cisagov/publish-egress-ip-terraform) that is allowed to be created by the role/policy specified in var.provisionpublishegressip\_role\_name. | `string` | `"PublishEgressIPLambda"` | no |
 | tags | Tags to apply to all AWS resources created. | `map(string)` | `{}` | no |
 
 ## Outputs ##
@@ -104,6 +114,7 @@ future changes by simply running `terraform apply
 | cw\_alarm\_sns\_topic | The SNS topic to which a message is sent when a CloudWatch alarm is triggered. |
 | primary\_delegation\_set | The primary reusable delegation set that contains the authoritative name servers for all public DNS zones. |
 | provisionaccount\_role | The IAM role that allows sufficient permissions to provision all AWS resources in the DNS account. |
+| provisionpublishegressip\_role | The IAM role that allows sufficient permissions to provision all resources related to the publish-egress-ip Lambda in the DNS account. |
 
 ## Contributing ##
 

--- a/dns/assume_role_policy_doc.tf
+++ b/dns/assume_role_policy_doc.tf
@@ -1,0 +1,20 @@
+# ------------------------------------------------------------------------------
+# Create an IAM policy document that allows the users account to
+# assume this role.
+# ------------------------------------------------------------------------------
+
+data "aws_iam_policy_document" "assume_role_doc" {
+  statement {
+    actions = [
+      "sts:AssumeRole",
+      "sts:TagSession",
+    ]
+
+    principals {
+      type = "AWS"
+      identifiers = [
+        "arn:aws:iam::${local.users_account_id}:root",
+      ]
+    }
+  }
+}

--- a/dns/assume_role_policy_doc.tf
+++ b/dns/assume_role_policy_doc.tf
@@ -1,6 +1,6 @@
 # ------------------------------------------------------------------------------
 # Create an IAM policy document that allows the users account to
-# assume this role.
+# assume a role.
 # ------------------------------------------------------------------------------
 
 data "aws_iam_policy_document" "assume_role_doc" {

--- a/dns/locals.tf
+++ b/dns/locals.tf
@@ -5,7 +5,16 @@ data "aws_organizations_organization" "cool" {
   provider = aws.organizationsreadonly
 }
 
+# ------------------------------------------------------------------------------
+# We can get the account ID of the DNS account from the default provider's
+# caller identity.
+# ------------------------------------------------------------------------------
+data "aws_caller_identity" "dns" {
+}
+
 locals {
+  dns_account_id = data.aws_caller_identity.dns.account_id
+
   # Find the Users account
   users_account_id = [
     for account in data.aws_organizations_organization.cool.accounts :

--- a/dns/outputs.tf
+++ b/dns/outputs.tf
@@ -8,6 +8,11 @@ output "provisionaccount_role" {
   description = "The IAM role that allows sufficient permissions to provision all AWS resources in the DNS account."
 }
 
+output "provisionpublishegressip_role" {
+  value       = aws_iam_role.provisionpublishegressip_role
+  description = "The IAM role that allows sufficient permissions to provision all resources related to the publish-egress-ip Lambda in the DNS account."
+}
+
 output "primary_delegation_set" {
   value       = aws_route53_delegation_set.primary
   description = "The primary reusable delegation set that contains the authoritative name servers for all public DNS zones."

--- a/dns/outputs.tf
+++ b/dns/outputs.tf
@@ -1,19 +1,19 @@
 output "cw_alarm_sns_topic" {
-  value       = module.cw_alarm_sns.sns_topic
   description = "The SNS topic to which a message is sent when a CloudWatch alarm is triggered."
+  value       = module.cw_alarm_sns.sns_topic
 }
 
 output "provisionaccount_role" {
-  value       = module.provisionaccount.provisionaccount_role
   description = "The IAM role that allows sufficient permissions to provision all AWS resources in the DNS account."
+  value       = module.provisionaccount.provisionaccount_role
 }
 
 output "provisionpublishegressip_role" {
-  value       = aws_iam_role.provisionpublishegressip_role
   description = "The IAM role that allows sufficient permissions to provision all resources related to the publish-egress-ip Lambda in the DNS account."
+  value       = aws_iam_role.provisionpublishegressip_role
 }
 
 output "primary_delegation_set" {
-  value       = aws_route53_delegation_set.primary
   description = "The primary reusable delegation set that contains the authoritative name servers for all public DNS zones."
+  value       = aws_route53_delegation_set.primary
 }

--- a/dns/outputs.tf
+++ b/dns/outputs.tf
@@ -3,6 +3,11 @@ output "cw_alarm_sns_topic" {
   value       = module.cw_alarm_sns.sns_topic
 }
 
+output "primary_delegation_set" {
+  description = "The primary reusable delegation set that contains the authoritative name servers for all public DNS zones."
+  value       = aws_route53_delegation_set.primary
+}
+
 output "provisionaccount_role" {
   description = "The IAM role that allows sufficient permissions to provision all AWS resources in the DNS account."
   value       = module.provisionaccount.provisionaccount_role
@@ -11,9 +16,4 @@ output "provisionaccount_role" {
 output "provisionpublishegressip_role" {
   description = "The IAM role that allows sufficient permissions to provision all resources related to the publish-egress-ip Lambda in the DNS account."
   value       = aws_iam_role.provisionpublishegressip_role
-}
-
-output "primary_delegation_set" {
-  description = "The primary reusable delegation set that contains the authoritative name servers for all public DNS zones."
-  value       = aws_route53_delegation_set.primary
 }

--- a/dns/provisionpublishegressip_policy.tf
+++ b/dns/provisionpublishegressip_policy.tf
@@ -1,0 +1,180 @@
+# ------------------------------------------------------------------------------
+# Create the IAM policy that allows provisioning all resources related to
+# the publish-egress-ip Lambda in the DNS account.
+# ------------------------------------------------------------------------------
+
+data "aws_iam_policy_document" "provisionpublishegressip_doc" {
+
+  statement {
+    actions = [
+      "acm:DescribeCertificate",
+      "acm:ListCertificates",
+      "acm:ListTagsForCertificate",
+    ]
+
+    resources = ["*"]
+  }
+
+  statement {
+    actions = [
+      "cloudfront:CreateDistribution",
+      "cloudfront:DeleteDistribution",
+      "cloudfront:GetDistribution",
+      "cloudfront:ListTagsForResource",
+      "cloudfront:TagResource",
+      "cloudfront:UpdateDistribution",
+    ]
+
+    resources = ["*"]
+  }
+
+  statement {
+    actions = [
+      "events:DeleteRule",
+      "events:DescribeRule",
+      "events:ListTagsForResource",
+      "events:ListTargetsByRule",
+      "events:PutRule",
+      "events:PutTargets",
+      "events:RemoveTargets",
+      "events:TagResource",
+    ]
+
+    resources = [
+      format("arn:aws:events:*:%s:rule/%s*",
+      local.dns_account_id, var.publishegressip_lambda_name)
+    ]
+  }
+
+  statement {
+    actions = [
+      "iam:CreatePolicy",
+      "iam:CreatePolicyVersion",
+      "iam:DeletePolicy",
+      "iam:DeletePolicyVersion",
+      "iam:GetPolicy",
+      "iam:GetPolicyVersion",
+      "iam:ListPolicyVersions",
+      "iam:TagPolicy",
+      "iam:UntagPolicy",
+    ]
+
+    resources = [
+      format("arn:aws:iam::%s:policy/%s",
+      local.dns_account_id, var.publishegressip_role_name),
+      format("arn:aws:iam::%s:policy/add_security_headers-role",
+      local.dns_account_id),
+    ]
+  }
+
+  statement {
+    actions = [
+      "iam:AttachRolePolicy",
+      "iam:CreateRole",
+      "iam:DeleteRole",
+      "iam:DeleteRolePolicy",
+      "iam:DetachRolePolicy",
+      "iam:GetRole",
+      "iam:GetRolePolicy",
+      "iam:ListAttachedRolePolicies",
+      "iam:ListInstanceProfilesForRole",
+      "iam:ListRolePolicies",
+      "iam:PassRole",
+      "iam:PutRolePolicy",
+      "iam:TagRole",
+      "iam:UpdateRoleDescription",
+    ]
+
+    resources = [
+      format("arn:aws:iam::%s:role/%s",
+      local.dns_account_id, var.publishegressip_role_name),
+      format("arn:aws:iam::%s:role/add_security_headers-role",
+      local.dns_account_id),
+    ]
+  }
+
+  statement {
+    actions = [
+      "iam:CreateServiceLinkedRole",
+    ]
+
+    resources = [
+      format("arn:aws:iam::%s:role/aws-service-role/replicator.lambda.amazonaws.com/AWSServiceRoleForLambdaReplicator", local.dns_account_id)
+    ]
+  }
+
+  statement {
+    actions = [
+      "lambda:AddPermission",
+      "lambda:CreateFunction",
+      "lambda:DeleteFunction",
+      "lambda:EnableReplication",
+      "lambda:GetFunction",
+      "lambda:GetFunctionCodeSigningConfig",
+      "lambda:GetPolicy",
+      "lambda:ListVersionsByFunction",
+      "lambda:RemovePermission",
+      "lambda:TagResource",
+      "lambda:UntagResource",
+      "lambda:UpdateFunctionCode",
+      "lambda:UpdateFunctionConfiguration",
+    ]
+
+    resources = [
+      format("arn:aws:lambda:*:%s:function:add_security_headers",
+      local.dns_account_id),
+      format("arn:aws:lambda:*:%s:function:add_security_headers:*",
+      local.dns_account_id),
+      format("arn:aws:lambda:*:%s:function:%s",
+      local.dns_account_id, var.publishegressip_lambda_name),
+      format("arn:aws:lambda:*:%s:function:%s:*",
+      local.dns_account_id, var.publishegressip_lambda_name),
+    ]
+  }
+
+  statement {
+    actions = [
+      "logs:CreateLogGroup",
+      "logs:DeleteLogGroup",
+      "logs:DescribeLogGroups",
+      "logs:ListTagsLogGroup",
+      "logs:PutRetentionPolicy",
+    ]
+
+    resources = [
+      format("arn:aws:logs:*:%s:log-group::log-stream:*", local.dns_account_id),
+      format("arn:aws:logs:*:%s:log-group:/aws/lambda/add_security_headers:log-stream:*",
+      local.dns_account_id),
+      format("arn:aws:logs:*:%s:log-group:/aws/lambda/%s:log-stream:*",
+      local.dns_account_id, var.publishegressip_lambda_name)
+    ]
+  }
+
+  statement {
+    actions = [
+      "s3:CreateBucket",
+      "s3:DeleteBucket",
+      "s3:DeleteBucketWebsite",
+      "s3:DeleteObject",
+      "s3:Get*",
+      "s3:ListBucket",
+      "s3:ListBucketVersions",
+      "s3:PutBucketAcl",
+      "s3:PutBucketPublicAccessBlock",
+      "s3:PutBucketTagging",
+      "s3:PutBucketVersioning",
+      "s3:PutBucketWebsite",
+      "s3:PutEncryptionConfiguration",
+      "s3:PutObject",
+      "s3:PutObjectTagging",
+    ]
+
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_policy" "provisionpublishegressip_policy" {
+  description = var.provisionpublishegressip_role_description
+  name        = var.provisionpublishegressip_role_name
+  policy      = data.aws_iam_policy_document.provisionpublishegressip_doc.json
+}

--- a/dns/provisionpublishegressip_policy.tf
+++ b/dns/provisionpublishegressip_policy.tf
@@ -156,6 +156,7 @@ data "aws_iam_policy_document" "provisionpublishegressip_doc" {
       "s3:DeleteBucket",
       "s3:DeleteBucketWebsite",
       "s3:DeleteObject",
+      "s3:DeleteObjectVersion",
       "s3:Get*",
       "s3:ListBucket",
       "s3:ListBucketVersions",

--- a/dns/provisionpublishegressip_policy.tf
+++ b/dns/provisionpublishegressip_policy.tf
@@ -1,6 +1,7 @@
 # ------------------------------------------------------------------------------
-# Create the IAM policy that allows provisioning all resources related to
-# the publish-egress-ip Lambda in the DNS account.
+# Create the IAM policy that allows all of the permissions necessary to
+# provision all resources related to the publish-egress-ip Lambda in
+# the DNS account.
 # ------------------------------------------------------------------------------
 
 data "aws_iam_policy_document" "provisionpublishegressip_doc" {

--- a/dns/provisionpublishegressip_role.tf
+++ b/dns/provisionpublishegressip_role.tf
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------------------
+# Create the IAM role that allows provisioning all resources related to
+# the publish-egress-ip Lambda in the DNS account.
+# ------------------------------------------------------------------------------
+
+resource "aws_iam_role" "provisionpublishegressip_role" {
+  assume_role_policy = data.aws_iam_policy_document.assume_role_doc.json
+  description        = var.provisionpublishegressip_role_description
+  name               = var.provisionpublishegressip_role_name
+}
+
+resource "aws_iam_role_policy_attachment" "provisionpublishegressip_policy_attachment" {
+  policy_arn = aws_iam_policy.provisionpublishegressip_policy.arn
+  role       = aws_iam_role.provisionpublishegressip_role.name
+}

--- a/dns/provisionpublishegressip_role.tf
+++ b/dns/provisionpublishegressip_role.tf
@@ -1,6 +1,7 @@
 # ------------------------------------------------------------------------------
-# Create the IAM role that allows provisioning all resources related to
-# the publish-egress-ip Lambda in the DNS account.
+# Create the IAM role that allows all of the permissions necessary to
+# provision all resources related to the publish-egress-ip Lambda in
+# the DNS account.
 # ------------------------------------------------------------------------------
 
 resource "aws_iam_role" "provisionpublishegressip_role" {

--- a/dns/variables.tf
+++ b/dns/variables.tf
@@ -22,6 +22,18 @@ variable "provisionaccount_role_name" {
   default     = "ProvisionAccount"
 }
 
+variable "provisionpublishegressip_role_description" {
+  type        = string
+  description = "The description to associate with the IAM role (as well as the corresponding policy) that allows sufficient permissions to provision all resources related to the publish-egress-ip Lambda in the DNS account."
+  default     = "Allows sufficient permissions to provision all resources related to the publish-egress-ip Lambda in the DNS account."
+}
+
+variable "provisionpublishegressip_role_name" {
+  type        = string
+  description = "The name to assign the IAM role (as well as the corresponding policy) that allows sufficient permissions to provision all resources related to the publish-egress-ip Lambda in the DNS account."
+  default     = "ProvisionPublishEgressIP"
+}
+
 variable "provisionroute53_role_description" {
   type        = string
   description = "The description to associate with the IAM role (as well as the corresponding policy) that allows sufficient permissions to provision Route 53 in the DNS account."
@@ -32,6 +44,18 @@ variable "provisionroute53_role_name" {
   type        = string
   description = "The name to assign the IAM role (as well as the corresponding policy) that allows sufficient permissions to provision Route 53 in the DNS account."
   default     = "ProvisionRoute53"
+}
+
+variable "publishegressip_lambda_name" {
+  type        = string
+  description = "The name of the Lambda function used in cisagov/publish-egress-ip-terraform.  This name is used to specify resource constraints in the role/policy specified in var.provisionpublishegressip_role_name."
+  default     = "publish-egress-ip"
+}
+
+variable "publishegressip_role_name" {
+  type        = string
+  description = "The name of the IAM role (meant to be used in cisagov/publish-egress-ip-terraform) that is allowed to be created by the role/policy specified in var.provisionpublishegressip_role_name."
+  default     = "PublishEgressIPLambda"
 }
 
 variable "tags" {


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR creates a role that includes the permissions necessary to provision all resources related to publishing egress IPs in the DNS account.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

This `ProvisionPublishEgressIP` role will be used by the forthcoming `cisagov/publish-egress-ip-terraform` repo, which will deploy all of the resources related to the egress IP publishing process in the DNS account.

This is part of the work for:
* https://github.com/cisagov/cool-system/issues/208
* https://github.com/cisagov/cyhy_amis/issues/284

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I successfully applied this code in the DNS account and I was also able to use the `ProvisionPublishEgressIP` role to successfully deploy test versions of all of the resources related to the egress IP publishing process.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] If any material changes were made during the PR approval process, apply them in the DNS account.
