### PR TITLE
Create policy/role for writing to assessment findings bucket

### DIFF
--- a/shared-services/README.md
+++ b/shared-services/README.md
@@ -102,7 +102,7 @@ future changes by simply running `terraform apply
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | assessment\_findings\_bucket\_name | The name of the assessment findings S3 bucket. | `string` | n/a | yes |
-| assessment\_findings\_bucket\_object\_name\_pattern | The name pattern specifying which objects are allowed to be written to the assessment findings data S3 bucket. | `string` | `"*-data.json"` | no |
+| assessment\_findings\_bucket\_object\_key\_pattern | The key pattern specifying which objects are allowed to be written to the assessment findings data S3 bucket. | `string` | `"*-data.json"` | no |
 | assessment\_findings\_bucket\_write\_role\_description | The description to associate with the IAM role that allows write access to the assessment findings S3 bucket. | `string` | `"Allows write permissions to the assessment findings S3 bucket."` | no |
 | assessment\_findings\_bucket\_write\_role\_name | The name to assign the IAM role that allows write access to the assessment findings S3 bucket. | `string` | `"AssessmentFindingsBucketWrite"` | no |
 | aws\_region | The AWS region where the non-global resources for the Shared Services account are to be provisioned (e.g. "us-east-1"). | `string` | `"us-east-1"` | no |

--- a/shared-services/README.md
+++ b/shared-services/README.md
@@ -85,9 +85,14 @@ future changes by simply running `terraform apply
 
 | Name | Type |
 |------|------|
+| [aws_iam_policy.assessment_findings_bucket_write](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.provisionssmsessionmanager_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_role.assessment_findings_bucket_write](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.assessment_findings_bucket_write](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.provisionssmsessionmanager_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_caller_identity.sharedservices](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_iam_policy_document.asseessment_account_assume_role_doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.assessment_findings_bucket_write](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.assume_role_doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.provisionssmsessionmanager_policy_doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_organizations_organization.cool](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/organizations_organization) | data source |
@@ -96,6 +101,10 @@ future changes by simply running `terraform apply
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| assessment\_findings\_bucket\_arn | The ARN of the assessment findings S3 bucket. | `string` | n/a | yes |
+| assessment\_findings\_bucket\_object\_name\_pattern | The name pattern specifying which objects are allowed to be written to the assessment findings data S3 bucket. | `string` | `"*-data.json"` | no |
+| assessment\_findings\_bucket\_write\_role\_description | The description to associate with the IAM role that allows write access to the assessment findings S3 bucket. | `string` | `"Allows write permissions to the assessment findings S3 bucket."` | no |
+| assessment\_findings\_bucket\_write\_role\_name | The name to assign the IAM role that allows write access to the assessment findings S3 bucket. | `string` | `"AssessmentFindingsBucketWrite"` | no |
 | aws\_region | The AWS region where the non-global resources for the Shared Services account are to be provisioned (e.g. "us-east-1"). | `string` | `"us-east-1"` | no |
 | provisionaccount\_role\_description | The description to associate with the IAM role that allows sufficient permissions to provision all AWS resources in the Shared Services account. | `string` | `"Allows sufficient permissions to provision all AWS resources in the Shared Services account."` | no |
 | provisionaccount\_role\_name | The name to assign the IAM role that allows sufficient permissions to provision all AWS resources in the Shared Services account. | `string` | `"ProvisionAccount"` | no |
@@ -107,6 +116,7 @@ future changes by simply running `terraform apply
 
 | Name | Description |
 |------|-------------|
+| assessment\_findings\_write\_role | The IAM role that allows write access to the assessment findings S3 bucket. |
 | cw\_alarm\_sns\_topic | The SNS topic to which a message is sent when a CloudWatch alarm is triggered. |
 | provisionaccount\_role | The IAM role that allows sufficient permissions to provision all AWS resources in the Shared Services account. |
 | ssm\_session\_role | The IAM role that allows creation of SSM Session Manager sessions to any EC2 instance in this account. |

--- a/shared-services/README.md
+++ b/shared-services/README.md
@@ -101,7 +101,7 @@ future changes by simply running `terraform apply
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| assessment\_findings\_bucket\_arn | The ARN of the assessment findings S3 bucket. | `string` | n/a | yes |
+| assessment\_findings\_bucket\_name | The name of the assessment findings S3 bucket. | `string` | n/a | yes |
 | assessment\_findings\_bucket\_object\_name\_pattern | The name pattern specifying which objects are allowed to be written to the assessment findings data S3 bucket. | `string` | `"*-data.json"` | no |
 | assessment\_findings\_bucket\_write\_role\_description | The description to associate with the IAM role that allows write access to the assessment findings S3 bucket. | `string` | `"Allows write permissions to the assessment findings S3 bucket."` | no |
 | assessment\_findings\_bucket\_write\_role\_name | The name to assign the IAM role that allows write access to the assessment findings S3 bucket. | `string` | `"AssessmentFindingsBucketWrite"` | no |

--- a/shared-services/assessment_accounts_assume_role_policy.tf
+++ b/shared-services/assessment_accounts_assume_role_policy.tf
@@ -1,0 +1,18 @@
+# ------------------------------------------------------------------------------
+# Create an IAM policy document that allows the dynamic assessment accounts to
+# assume a role.
+# ------------------------------------------------------------------------------
+
+data "aws_iam_policy_document" "asseessment_account_assume_role_doc" {
+  statement {
+    actions = [
+      "sts:AssumeRole",
+      "sts:TagSession",
+    ]
+    effect = "Allow"
+    principals {
+      type        = "AWS"
+      identifiers = local.assessment_account_ids
+    }
+  }
+}

--- a/shared-services/assessment_findings_write_policy.tf
+++ b/shared-services/assessment_findings_write_policy.tf
@@ -9,7 +9,7 @@ data "aws_iam_policy_document" "assessment_findings_bucket_write" {
       "s3:PutObject",
     ]
     resources = [
-      "arn:aws:s3:::${var.assessment_findings_bucket_name}/${var.assessment_findings_bucket_object_name_pattern}",
+      "arn:aws:s3:::${var.assessment_findings_bucket_name}/${var.assessment_findings_bucket_object_key_pattern}",
     ]
   }
 }

--- a/shared-services/assessment_findings_write_policy.tf
+++ b/shared-services/assessment_findings_write_policy.tf
@@ -1,0 +1,22 @@
+# ------------------------------------------------------------------------------
+# Create the IAM policy that allows write access to the assessment findings S3
+# bucket (specified by var.assessment_findings_bucket_arn).
+# ------------------------------------------------------------------------------
+
+data "aws_iam_policy_document" "assessment_findings_bucket_write" {
+  statement {
+    actions = [
+      "s3:PutObject",
+    ]
+    resources = [
+      "${var.assessment_findings_bucket_arn}/${var.assessment_findings_bucket_object_name_pattern}",
+    ]
+  }
+}
+
+# The IAM policy for write access to the assessment findings bucket
+resource "aws_iam_policy" "assessment_findings_bucket_write" {
+  description = var.assessment_findings_bucket_write_role_description
+  name        = var.assessment_findings_bucket_write_role_name
+  policy      = data.aws_iam_policy_document.assessment_findings_bucket_write.json
+}

--- a/shared-services/assessment_findings_write_policy.tf
+++ b/shared-services/assessment_findings_write_policy.tf
@@ -1,6 +1,6 @@
 # ------------------------------------------------------------------------------
 # Create the IAM policy that allows write access to the assessment findings S3
-# bucket (specified by var.assessment_findings_bucket_arn).
+# bucket (specified by var.assessment_findings_bucket_name).
 # ------------------------------------------------------------------------------
 
 data "aws_iam_policy_document" "assessment_findings_bucket_write" {
@@ -9,7 +9,7 @@ data "aws_iam_policy_document" "assessment_findings_bucket_write" {
       "s3:PutObject",
     ]
     resources = [
-      "${var.assessment_findings_bucket_arn}/${var.assessment_findings_bucket_object_name_pattern}",
+      "arn:aws:s3:::${var.assessment_findings_bucket_name}/${var.assessment_findings_bucket_object_name_pattern}",
     ]
   }
 }

--- a/shared-services/assessment_findings_write_role.tf
+++ b/shared-services/assessment_findings_write_role.tf
@@ -1,6 +1,6 @@
 # ------------------------------------------------------------------------------
 # Create the IAM role that allows write access to the assessment findings S3
-# bucket (specified by var.assessment_findings_bucket_arn).
+# bucket (specified by var.assessment_findings_bucket_name).
 # ------------------------------------------------------------------------------
 
 resource "aws_iam_role" "assessment_findings_bucket_write" {

--- a/shared-services/assessment_findings_write_role.tf
+++ b/shared-services/assessment_findings_write_role.tf
@@ -1,0 +1,16 @@
+# ------------------------------------------------------------------------------
+# Create the IAM role that allows write access to the assessment findings S3
+# bucket (specified by var.assessment_findings_bucket_arn).
+# ------------------------------------------------------------------------------
+
+resource "aws_iam_role" "assessment_findings_bucket_write" {
+  assume_role_policy = data.aws_iam_policy_document.asseessment_account_assume_role_doc.json
+  description        = var.assessment_findings_bucket_write_role_description
+  name               = var.assessment_findings_bucket_write_role_name
+}
+
+# Attach the IAM policy to the role
+resource "aws_iam_role_policy_attachment" "assessment_findings_bucket_write" {
+  policy_arn = aws_iam_policy.assessment_findings_bucket_write.arn
+  role       = aws_iam_role.assessment_findings_bucket_write.name
+}

--- a/shared-services/locals.tf
+++ b/shared-services/locals.tf
@@ -6,6 +6,23 @@ data "aws_organizations_organization" "cool" {
 }
 
 locals {
+  # Find the Shared Services account name by id.
+  sharedservices_account_name = [
+    for x in data.aws_organizations_organization.cool.accounts :
+    x.name if x.id == data.aws_caller_identity.sharedservices.account_id
+  ][0]
+
+  # Determine the dynamic assessment account ("env*") IDs that are the same
+  # type (production, staging, etc.) as the Shared Services account.
+  sharedservices_account_type = trim(split("(", local.sharedservices_account_name)[1], ")")
+
+  assessment_account_name_regex = format("^env[[:digit:]]+ \\(%s\\)$", local.sharedservices_account_type)
+
+  assessment_account_ids = [
+    for account in data.aws_organizations_organization.cool.non_master_accounts :
+    account.id
+  if length(regexall(local.assessment_account_name_regex, account.name)) > 0]
+
   # Find the Users account
   users_account_id = [
     for account in data.aws_organizations_organization.cool.accounts :

--- a/shared-services/outputs.tf
+++ b/shared-services/outputs.tf
@@ -1,3 +1,8 @@
+output "assessment_findings_write_role" {
+  value       = aws_iam_role.assessment_findings_bucket_write
+  description = "The IAM role that allows write access to the assessment findings S3 bucket."
+}
+
 output "cw_alarm_sns_topic" {
   value       = module.cw_alarm_sns.sns_topic
   description = "The SNS topic to which a message is sent when a CloudWatch alarm is triggered."

--- a/shared-services/variables.tf
+++ b/shared-services/variables.tf
@@ -16,9 +16,9 @@ variable "assessment_findings_bucket_name" {
 # These parameters have reasonable defaults.
 # ------------------------------------------------------------------------------
 
-variable "assessment_findings_bucket_object_name_pattern" {
+variable "assessment_findings_bucket_object_key_pattern" {
   type        = string
-  description = "The name pattern specifying which objects are allowed to be written to the assessment findings data S3 bucket."
+  description = "The key pattern specifying which objects are allowed to be written to the assessment findings data S3 bucket."
   default     = "*-data.json"
 }
 

--- a/shared-services/variables.tf
+++ b/shared-services/variables.tf
@@ -1,8 +1,38 @@
 # ------------------------------------------------------------------------------
+# REQUIRED PARAMETERS
+#
+# You must provide a value for each of these parameters.
+# ------------------------------------------------------------------------------
+
+# This bucket is created by cisagov/findings-data-import-terraform.
+variable "assessment_findings_bucket_arn" {
+  type        = string
+  description = "The ARN of the assessment findings S3 bucket."
+}
+
+# ------------------------------------------------------------------------------
 # OPTIONAL PARAMETERS
 #
 # These parameters have reasonable defaults.
 # ------------------------------------------------------------------------------
+
+variable "assessment_findings_bucket_object_name_pattern" {
+  type        = string
+  description = "The name pattern specifying which objects are allowed to be written to the assessment findings data S3 bucket."
+  default     = "*-data.json"
+}
+
+variable "assessment_findings_bucket_write_role_description" {
+  type        = string
+  description = "The description to associate with the IAM role that allows write access to the assessment findings S3 bucket."
+  default     = "Allows write permissions to the assessment findings S3 bucket."
+}
+
+variable "assessment_findings_bucket_write_role_name" {
+  type        = string
+  description = "The name to assign the IAM role that allows write access to the assessment findings S3 bucket."
+  default     = "AssessmentFindingsBucketWrite"
+}
 
 variable "aws_region" {
   type        = string

--- a/shared-services/variables.tf
+++ b/shared-services/variables.tf
@@ -5,9 +5,9 @@
 # ------------------------------------------------------------------------------
 
 # This bucket is created by cisagov/findings-data-import-terraform.
-variable "assessment_findings_bucket_arn" {
+variable "assessment_findings_bucket_name" {
   type        = string
-  description = "The ARN of the assessment findings S3 bucket."
+  description = "The name of the assessment findings S3 bucket."
 }
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR creates a policy and role that allows writing to the assessment findings bucket.  The role is only assumable from the assessment environment accounts.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

We want to allow data to be copied from COOL assessment environments to the assessment findings bucket.

Related to:
* https://github.com/cisagov/findings-data-import-terraform/pull/34
* https://github.com/cisagov/cool-assessment-terraform/pull/207

This is part of the work required for https://github.com/cisagov/cool-system-internal/issues/122.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I successfully applied this Terraform in Staging (after I applied the Terraform in https://github.com/cisagov/findings-data-import-terraform/pull/34) and confirmed the following:
* I was able to assume the role created by this PR from within one of the Staging assessment environments.
* After assuming the role created by this PR, I was able to write an object to the assessment findings bucket.
* I was not allowed to assume the role created by this PR from a different (non-Staging assessment) AWS account.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.


## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [x] Update Production Terraform variables file.
- [x] Apply changes in Production workspace.
- [x] Commit updated Terraform variables file.
- [x] Ensure that documentation for adding new assessment environments includes re-applying this Terraform so that new accounts are added to this policy - see https://github.com/cisagov/cool-system-internal/pull/123.
