### PR TITLE
Use the renamed and generalized cisagov/sns-send-to-account-email-tf-module

### DIFF
--- a/audit/README.md
+++ b/audit/README.md
@@ -75,7 +75,7 @@ future changes by simply running `terraform apply
 
 | Name | Source | Version |
 |------|--------|---------|
-| cw\_alarm\_sns | github.com/cisagov/cw-alarm-sns-tf-module | n/a |
+| cw\_alarm\_sns | github.com/cisagov/sns-send-to-account-email-tf-module | n/a |
 | provisionaccount | github.com/cisagov/provisionaccount-role-tf-module | n/a |
 
 ## Resources ##

--- a/audit/sns.tf
+++ b/audit/sns.tf
@@ -8,5 +8,8 @@ module "cw_alarm_sns" {
     aws                         = aws
     aws.organizations_read_only = aws.organizationsreadonly
   }
-  source = "github.com/cisagov/cw-alarm-sns-tf-module"
+  source = "github.com/cisagov/sns-send-to-account-email-tf-module"
+
+  topic_name         = "cloudwatch-alarms"
+  topic_display_name = "cloudwatch_alarms"
 }

--- a/dns/README.md
+++ b/dns/README.md
@@ -76,7 +76,7 @@ future changes by simply running `terraform apply
 
 | Name | Source | Version |
 |------|--------|---------|
-| cw\_alarm\_sns | github.com/cisagov/cw-alarm-sns-tf-module | n/a |
+| cw\_alarm\_sns | github.com/cisagov/sns-send-to-account-email-tf-module | n/a |
 | provisionaccount | github.com/cisagov/provisionaccount-role-tf-module | n/a |
 
 ## Resources ##

--- a/dns/sns.tf
+++ b/dns/sns.tf
@@ -8,5 +8,8 @@ module "cw_alarm_sns" {
     aws                         = aws
     aws.organizations_read_only = aws.organizationsreadonly
   }
-  source = "github.com/cisagov/cw-alarm-sns-tf-module"
+  source = "github.com/cisagov/sns-send-to-account-email-tf-module"
+
+  topic_name         = "cloudwatch-alarms"
+  topic_display_name = "cloudwatch_alarms"
 }

--- a/dynamic/README.md
+++ b/dynamic/README.md
@@ -84,7 +84,7 @@ future changes by simply running `terraform apply
 
 | Name | Source | Version |
 |------|--------|---------|
-| cw\_alarm\_sns | github.com/cisagov/cw-alarm-sns-tf-module | n/a |
+| cw\_alarm\_sns | github.com/cisagov/sns-send-to-account-email-tf-module | n/a |
 | provisionaccount | github.com/cisagov/provisionaccount-role-tf-module | n/a |
 
 ## Resources ##

--- a/dynamic/sns.tf
+++ b/dynamic/sns.tf
@@ -8,5 +8,8 @@ module "cw_alarm_sns" {
     aws                         = aws
     aws.organizations_read_only = aws.organizationsreadonly
   }
-  source = "github.com/cisagov/cw-alarm-sns-tf-module"
+  source = "github.com/cisagov/sns-send-to-account-email-tf-module"
+
+  topic_name         = "cloudwatch-alarms"
+  topic_display_name = "cloudwatch_alarms"
 }

--- a/images/README.md
+++ b/images/README.md
@@ -81,7 +81,7 @@ future changes by simply running `terraform apply
 
 | Name | Source | Version |
 |------|--------|---------|
-| cw\_alarm\_sns | github.com/cisagov/cw-alarm-sns-tf-module | n/a |
+| cw\_alarm\_sns | github.com/cisagov/sns-send-to-account-email-tf-module | n/a |
 | provisionaccount | github.com/cisagov/provisionaccount-role-tf-module | n/a |
 
 ## Resources ##

--- a/images/sns.tf
+++ b/images/sns.tf
@@ -8,5 +8,8 @@ module "cw_alarm_sns" {
     aws                         = aws
     aws.organizations_read_only = aws.organizationsreadonly
   }
-  source = "github.com/cisagov/cw-alarm-sns-tf-module"
+  source = "github.com/cisagov/sns-send-to-account-email-tf-module"
+
+  topic_name         = "cloudwatch-alarms"
+  topic_display_name = "cloudwatch_alarms"
 }

--- a/log-archive/README.md
+++ b/log-archive/README.md
@@ -75,7 +75,7 @@ future changes by simply running `terraform apply
 
 | Name | Source | Version |
 |------|--------|---------|
-| cw\_alarm\_sns | github.com/cisagov/cw-alarm-sns-tf-module | n/a |
+| cw\_alarm\_sns | github.com/cisagov/sns-send-to-account-email-tf-module | n/a |
 | provisionaccount | github.com/cisagov/provisionaccount-role-tf-module | n/a |
 
 ## Resources ##

--- a/log-archive/sns.tf
+++ b/log-archive/sns.tf
@@ -8,5 +8,8 @@ module "cw_alarm_sns" {
     aws                         = aws
     aws.organizations_read_only = aws.organizationsreadonly
   }
-  source = "github.com/cisagov/cw-alarm-sns-tf-module"
+  source = "github.com/cisagov/sns-send-to-account-email-tf-module"
+
+  topic_name         = "cloudwatch-alarms"
+  topic_display_name = "cloudwatch_alarms"
 }

--- a/master/README.md
+++ b/master/README.md
@@ -75,7 +75,7 @@ future changes by simply running `terraform apply
 
 | Name | Source | Version |
 |------|--------|---------|
-| cw\_alarm\_sns | github.com/cisagov/cw-alarm-sns-tf-module | n/a |
+| cw\_alarm\_sns | github.com/cisagov/sns-send-to-account-email-tf-module | n/a |
 | provisionaccount | github.com/cisagov/provisionaccount-role-tf-module | n/a |
 
 ## Resources ##

--- a/master/sns.tf
+++ b/master/sns.tf
@@ -8,5 +8,8 @@ module "cw_alarm_sns" {
     aws                         = aws
     aws.organizations_read_only = aws
   }
-  source = "github.com/cisagov/cw-alarm-sns-tf-module"
+  source = "github.com/cisagov/sns-send-to-account-email-tf-module"
+
+  topic_name         = "cloudwatch-alarms"
+  topic_display_name = "cloudwatch_alarms"
 }

--- a/shared-services/README.md
+++ b/shared-services/README.md
@@ -77,7 +77,7 @@ future changes by simply running `terraform apply
 
 | Name | Source | Version |
 |------|--------|---------|
-| cw\_alarm\_sns | github.com/cisagov/cw-alarm-sns-tf-module | n/a |
+| cw\_alarm\_sns | github.com/cisagov/sns-send-to-account-email-tf-module | n/a |
 | provisionaccount | github.com/cisagov/provisionaccount-role-tf-module | n/a |
 | session\_manager | github.com/cisagov/session-manager-tf-module | n/a |
 

--- a/shared-services/sns.tf
+++ b/shared-services/sns.tf
@@ -8,5 +8,8 @@ module "cw_alarm_sns" {
     aws                         = aws
     aws.organizations_read_only = aws.organizationsreadonly
   }
-  source = "github.com/cisagov/cw-alarm-sns-tf-module"
+  source = "github.com/cisagov/sns-send-to-account-email-tf-module"
+
+  topic_name         = "cloudwatch-alarms"
+  topic_display_name = "cloudwatch_alarms"
 }

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -115,7 +115,7 @@ after you bootstrap the Users account.
 
 | Name | Source | Version |
 |------|--------|---------|
-| cw\_alarm\_sns | github.com/cisagov/cw-alarm-sns-tf-module | n/a |
+| cw\_alarm\_sns | github.com/cisagov/sns-send-to-account-email-tf-module | n/a |
 | provisionaccount | github.com/cisagov/provisionaccount-role-tf-module | n/a |
 
 ## Resources ##

--- a/terraform/sns.tf
+++ b/terraform/sns.tf
@@ -8,5 +8,8 @@ module "cw_alarm_sns" {
     aws                         = aws
     aws.organizations_read_only = aws.organizationsreadonly
   }
-  source = "github.com/cisagov/cw-alarm-sns-tf-module"
+  source = "github.com/cisagov/sns-send-to-account-email-tf-module"
+
+  topic_name         = "cloudwatch-alarms"
+  topic_display_name = "cloudwatch_alarms"
 }

--- a/users/README.md
+++ b/users/README.md
@@ -124,7 +124,7 @@ future changes by simply running `terraform apply
 
 | Name | Source | Version |
 |------|--------|---------|
-| cw\_alarm\_sns | github.com/cisagov/cw-alarm-sns-tf-module | n/a |
+| cw\_alarm\_sns | github.com/cisagov/sns-send-to-account-email-tf-module | n/a |
 | provisionaccount | github.com/cisagov/provisionaccount-role-tf-module | n/a |
 
 ## Resources ##

--- a/users/sns.tf
+++ b/users/sns.tf
@@ -8,5 +8,8 @@ module "cw_alarm_sns" {
     aws                         = aws
     aws.organizations_read_only = aws.organizationsreadonly
   }
-  source = "github.com/cisagov/cw-alarm-sns-tf-module"
+  source = "github.com/cisagov/sns-send-to-account-email-tf-module"
+
+  topic_name         = "cloudwatch-alarms"
+  topic_display_name = "cloudwatch_alarms"
 }


### PR DESCRIPTION
## 🗣 Description ##

This pull request modifies the repo to make use of the renamed and slightly generalized [cisagov/sns-send-to-account-email-tf-module](https://github.com/cisagov/sns-send-to-account-email-tf-module) repo vice the old [cisagov/cw-alarms-sns-tf-module](https://github.com/cisagov/cw-alarms-sns-tf-module) repo.

## 💭 Motivation and context ##

We want to use the same sort of functionality for sending emails when IAM or SSO user accounts are created, so it makes sense to rename and generalize the repo.

See also:
- cisagov/sns-send-to-account-email-tf-module#23
- cisagov/cool-accounts-pca#32
- cisagov/cool-accounts-domain-manager#29

## 🧪 Testing ##

All automated tests pass.  I also successfully applied the the changes in this branch to [the `audit` subdirectory of cisagov/cool-accounts](https://github.com/cisagov/cool-accounts) in COOL production.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Post-merge checklist ##

- [x] Ensure that these changes are applied to all of the non-dynamic accounts in both Staging and Production.