### PR TITLE
Add `acm:GetCertificate` to policy to provision resources for publish-egress-ip Lambda

### DIFF
--- a/dns/provisionpublishegressip_policy.tf
+++ b/dns/provisionpublishegressip_policy.tf
@@ -9,6 +9,7 @@ data "aws_iam_policy_document" "provisionpublishegressip_doc" {
   statement {
     actions = [
       "acm:DescribeCertificate",
+      "acm:GetCertificate",
       "acm:ListCertificates",
       "acm:ListTagsForCertificate",
     ]


### PR DESCRIPTION

# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR adds the `acm:GetCertificate` permission to the policy used to provision resources for the [publish-egress-ip Lambda](https://github.com/cisagov/publish-egress-ip-lambda).

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Previously, this permission was not required in order to successfully apply [`cisagov/publish-egress-ip-terraform`](https://github.com/cisagov/publish-egress-ip-terraform), but now it is.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I was able to successfully apply this Terraform.  I confirmed that the new permission functioned as intended, because I was then able to successfully apply the Terraform in [`cisagov/publish-egress-ip-terraform`](https://github.com/cisagov/publish-egress-ip-terraform).

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.