### PR TITLE
Modify permissions in `ProvisionPublishEgressIP` policy

### DIFF
--- a/dns/provisionpublishegressip_policy.tf
+++ b/dns/provisionpublishegressip_policy.tf
@@ -167,7 +167,6 @@ data "aws_iam_policy_document" "provisionpublishegressip_doc" {
       "s3:Get*",
       "s3:ListBucket",
       "s3:ListBucketVersions",
-      "s3:PutBucketAcl",
       "s3:PutBucketOwnershipControls",
       "s3:PutBucketPolicy",
       "s3:PutBucketPublicAccessBlock",

--- a/dns/provisionpublishegressip_policy.tf
+++ b/dns/provisionpublishegressip_policy.tf
@@ -28,6 +28,7 @@ data "aws_iam_policy_document" "provisionpublishegressip_doc" {
       "cloudfront:ListTagsForResource",
       "cloudfront:TagResource",
       "cloudfront:UpdateDistribution",
+      "cloudfront:UpdateOriginAccessControl",
     ]
 
     resources = ["*"]


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR makes two permission changes to the `ProvisionPublishEgressIP` policy:
* Add `cloudfront:UpdateOriginAccessControl` (https://github.com/cisagov/cool-accounts/commit/5f1588203e5b7f81cbd7ced0bd94a4f24321787d)
* Remove `s3:PutBucketAcl` (https://github.com/cisagov/cool-accounts/commit/8ef0ac55fb032eaba0ea6729751294f9241abf7f)

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

* `cloudfront:UpdateOriginAccessControl` was needed during development and may be needed in the future if the OAC is ever changed.
* `s3:PutBucketAcl` is not needed since we are no longer using an ACL for the egress info bucket.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

These changes were applied successfully and I verified that the updated permissions were adequate to apply the code in `cisagov/publish-egress-ip-terraform`.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
