### PR TITLE
Add lambda:ListTags permission to ProvisionPublishEgressIP policy

### DIFF
--- a/dns/provisionpublishegressip_policy.tf
+++ b/dns/provisionpublishegressip_policy.tf
@@ -118,6 +118,7 @@ data "aws_iam_policy_document" "provisionpublishegressip_doc" {
       "lambda:GetFunction",
       "lambda:GetFunctionCodeSigningConfig",
       "lambda:GetPolicy",
+      "lambda:ListTags",
       "lambda:ListVersionsByFunction",
       "lambda:RemovePermission",
       "lambda:TagResource",


### PR DESCRIPTION

# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR adds the `lambda:ListTags` permission to the `ProvisionPublishEgressIP` policy.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

We want to maintain our current level of functionality.

AWS Support writes:

> Previously, permissions on ListTags were required only when using the ListTags API explicitly. However, principals with GetFunction API permissions could still access tag information outputted by the GetFunction call even if there is an explicit deny on ListTags API. Beginning October 2, 2024, Lambda will return tags data only when the principal calling GetFunction API has a policy with an explicit allow permission on ListTags API. When the role calling the GetFunction API has a policy with a deny or has no policy with explicit allow access to ListTags API, Lambda will not return tags data in the response to the GetFunction API call.

For reference: https://docs.aws.amazon.com/lambda/latest/dg/configuration-tags.html#permissions-required-for-working-with-tags-cli

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

👀

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

