### PR TITLE
Update logic to support legacy and new Images account naming scheme

### DIFF
--- a/images/locals.tf
+++ b/images/locals.tf
@@ -45,7 +45,7 @@ locals {
   # workspace name as the account type.
   this_account_type = length(regexall("\\(([^()]*)\\)", local.this_account_name)) == 1 ? regex("\\(([^()]*)\\)", local.this_account_name)[0] : terraform.workspace
 
-  # Find the Users account by name and email
+  # Find the Users account by name
   users_account_id = [
     for account in data.aws_organizations_organization.cool.accounts :
     account.id if account.name == "Users"

--- a/images/locals.tf
+++ b/images/locals.tf
@@ -37,7 +37,13 @@ locals {
   # Determine Images account type based on AWS account name
   # Account name format:  "ACCOUNT_NAME (ACCOUNT_TYPE)"
   #         For example:  "Images (Production)"
-  this_account_type = length(regexall("\\(([^()]*)\\)", local.this_account_name)) == 1 ? regex("\\(([^()]*)\\)", local.this_account_name)[0] : "Unknown"
+  # NOTE: Originally, Images account names followed the "Images (ACCOUNT_TYPE)"
+  # format above, but our thinking has changed and in newer environments the
+  # account is simply called "Images".  However, until all legacy environments
+  # have been migrated to this new naming scheme, we must check the account name
+  # via the regex below and if there is no match, then we use the Terraform
+  # workspace name as the account type.
+  this_account_type = length(regexall("\\(([^()]*)\\)", local.this_account_name)) == 1 ? regex("\\(([^()]*)\\)", local.this_account_name)[0] : terraform.workspace
 
   # Find the Users account by name and email
   users_account_id = [


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR updates logic to handle our legacy Images account naming scheme (`"Images (ACCOUNT_TYPE)"`) as well as our current scheme (`"Images"`).  In the current scheme, the Terraform workspace name is used to represent the account type.

I also took this opportunity to correct a comment that I noticed was no longer accurate (see https://github.com/cisagov/cool-accounts/commit/4c6cdc469eea230f09b737cabdcf070b89fec270).

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Originally, Images account names followed the `"Images (ACCOUNT_TYPE)"` format, but our thinking has changed and in newer environments the account is simply called `"Images"`.  However, until all legacy environments have been migrated to this new naming scheme, we must check the account name via the regex below and if there is no match, then we use the Terraform workspace name as the account type.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I successfully applied this code in a new staging environment that I'm setting up.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
