### PR TITLE
Support new COOL environment structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,5 @@ __pycache__
 .terraform.lock.hcl
 terraform.tfstate
 terraform.tfstate.backup
+*.tfconfig
 *.tfvars

--- a/audit/README.md
+++ b/audit/README.md
@@ -1,27 +1,29 @@
 # cool-accounts - audit subdirectory #
 
-This subdirectory contains Terraform code to provision the COOL
-Audit account.  It creates an IAM role that allows sufficient
-permissions to provision all AWS resources in this account.  This role
-has a trust relationship with the Users account.
+This subdirectory contains Terraform code to provision the COOL Audit account.
+It creates an IAM role that allows sufficient permissions to provision all AWS
+resources in this account.  This role has a trust relationship with the Users
+account.
 
 ## Bootstrapping this account ##
 
-Note that this account must be bootstrapped.  This is because there is
-no IAM role that can be assumed to build out these resources.
-Therefore you must first apply this Terraform code with programmatic
-credentials for AWSAdministratorAccess as obtained for the COOL Audit
-account from the AWS SSO page.
+Note that this account must be bootstrapped.  This is because there is no IAM
+role that can be assumed to build out these resources. Therefore you must first
+apply this Terraform code with programmatic credentials for
+AWSAdministratorAccess as obtained for the COOL Audit account from the AWS SSO
+page.
 
-To do this, follow these steps:
+To do this, follow these steps (for the purposes of these instructions, assume
+the environment is named "dev"; replace "dev" in the instructions below with
+your environment name if needed):
 
-1. Comment out the `profile = "cool-audit-provisionaccount"` line for
-   the "default" provider in `providers.tf` and directly below that
-   uncomment the line `profile = "cool-audit-account-admin"`.
-1. Create a new AWS profile called `cool-audit-account-admin`
-   in your Boto3 configuration using the "AWSAdministratorAccess"
-   credentials (access key ID, secret access key, and session token)
-   as obtained from the COOL Audit account:
+1. Comment out the `profile = "cool-audit-provisionaccount"` line for the
+   "default" provider in `providers.tf` and directly below that uncomment the
+   line `profile = "cool-audit-account-admin"`.
+1. Create a new AWS profile called `cool-audit-account-admin` in your Boto3
+   configuration using the "AWSAdministratorAccess" credentials (access key ID,
+   secret access key, and session token) as obtained from the COOL Audit
+   account:
 
    ```console
    [cool-audit-account-admin]
@@ -30,33 +32,61 @@ To do this, follow these steps:
    aws_session_token = <MY_SESSION_TOKEN>
    ```
 
-1. Ensure that the bucket name in `backend.tf` is correct.  It should match
-   the `state_bucket_name` specified in the `tfvars` file that you used to
-   bootstrap the [`cool-accounts/terraform`](../terraform) directory.
-1. Run the command `terraform init -upgrade`.  Note that if you have previously
-   used a different Terraform backend (e.g. for a different environment), you
-   will need to run `terraform init -reconfigure -upgrade`.
+1. Create a backend configuration file named `dev.tfconfig` containing the name
+   of the bucket where Terraform state is stored for that environment.  The
+   bucket name should match the `state_bucket_name` specified in the `tfvars`
+   file that you used to bootstrap the [`cool-accounts/terraform`](../terraform)
+   directory.  This file is required to initialize the Terraform backend in each
+   environment:
+
+    ```hcl
+    bucket = "my-dev-terraform-state-bucket"
+    ```
+
+1. Initialize the Terraform backend for the "dev" environment using your backend
+   configuration file:
+
+    ```console
+    terraform init -upgrade -backend-config=dev.tfconfig
+    ```
+
+    > [!NOTE] When performing this step for additional environments (i.e. not
+    > your first environment), use the `-reconfigure` flag:
+    >
+    > ```console
+    > terraform init -upgrade -backend-config=other-env.tfconfig -reconfigure
+    > ```
+
 1. Create a Terraform workspace (if you haven't already done so) by running
-   `terraform workspace new <workspace_name>`
-1. Create a `<workspace_name>.tfvars` file with any optional variables
-   that you wish to override (see [Inputs](#inputs) below for
-   details):
+   `terraform workspace new dev`
+1. Create a `dev.tfvars` file with any optional variables that you wish to
+   override (see [Inputs](#inputs) below for details):
 
    ```console
    tags = {
      Team        = "VM Fusion - Development"
      Application = "COOL - Audit Account"
-     Workspace   = "production"
+     Workspace   = "dev"
    }
    ```
 
-1. Run the command `terraform apply -var-file=<workspace_name>.tfvars`.
+1. Run the command `terraform apply -var-file=dev.tfvars`.
 1. Revert the changes you made to `providers.tf` in step 1.
-1. Run the command `terraform apply -var-file=<workspace_name>.tfvars`.
+1. If you haven't already done so, create a new AWS profile called
+   `cool-audit-provisionaccount` in your local configuration that includes the
+   `provisionaccount_role` ARN output from the previous step, for example:
 
-At this point the account has been bootstrapped, and you can apply
-future changes by simply running `terraform apply
--var-file=<workspace_name>.tfvars`.
+   ```ini
+   [cool-audit-provisionaccount]
+   role_arn = arn:aws:iam::111111111111:role/ProvisionAccount
+   role_session_name = your.session.name
+   source_profile = cool-user-base-profile
+   ```
+
+1. Run the command `terraform apply -var-file=dev.tfvars`.
+
+At this point the account has been bootstrapped, and you can apply future
+changes by simply running `terraform apply -var-file=dev.tfvars`.
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements ##

--- a/audit/backend.tf
+++ b/audit/backend.tf
@@ -1,6 +1,10 @@
 terraform {
   backend "s3" {
-    bucket         = "cisa-cool-terraform-state"
+    # Use a partial configuration to avoid hardcoding the bucket name. This
+    # allows the bucket name to be set on a per-environment basis via the
+    # -backend-config command line option or other methods.  For details, see:
+    # https://developer.hashicorp.com/terraform/language/backend#partial-configuration
+    bucket         = ""
     dynamodb_table = "terraform-state-lock"
     encrypt        = true
     key            = "cool-accounts/audit.tfstate"

--- a/dns/README.md
+++ b/dns/README.md
@@ -1,27 +1,28 @@
 # cool-accounts - dns subdirectory #
 
-This subdirectory contains Terraform code to provision the COOL DNS
-account.  It creates an IAM role that allows sufficient permissions to
-provision all AWS resources in this account.  This role has a trust
-relationship with the Users account.
+This subdirectory contains Terraform code to provision the COOL DNS account.  It
+creates an IAM role that allows sufficient permissions to provision all AWS
+resources in this account.  This role has a trust relationship with the Users
+account.
 
 ## Bootstrapping this account ##
 
-Note that this account must be bootstrapped.  This is because there is
-no IAM role that can be assumed to build out these resources.
-Therefore you must first apply this Terraform code with programmatic
-credentials for AWSAdministratorAccess as obtained for the COOL DNS
-account from the AWS SSO page.
+Note that this account must be bootstrapped.  This is because there is no IAM
+role that can be assumed to build out these resources. Therefore you must first
+apply this Terraform code with programmatic credentials for
+AWSAdministratorAccess as obtained for the COOL DNS account from the AWS SSO
+page.
 
-To do this, follow these steps:
+To do this, follow these steps (for the purposes of these instructions, assume
+the environment is named "dev"; replace "dev" in the instructions below with
+your environment name if needed):
 
-1. Comment out the `profile = "cool-dns-provisionaccount"` line for
-   the "default" provider in `providers.tf` and directly below that
-   uncomment the line `profile = "cool-dns-account-admin"`.
-1. Create a new AWS profile called `cool-dns-account-admin`
-   in your Boto3 configuration using the "AWSAdministratorAccess"
-   credentials (access key ID, secret access key, and session token)
-   as obtained from the COOL dns account:
+1. Comment out the `profile = "cool-dns-provisionaccount"` line for the
+   "default" provider in `providers.tf` and directly below that uncomment the
+   line `profile = "cool-dns-account-admin"`.
+1. Create a new AWS profile called `cool-dns-account-admin` in your Boto3
+   configuration using the "AWSAdministratorAccess" credentials (access key ID,
+   secret access key, and session token) as obtained from the COOL dns account:
 
    ```console
    [cool-dns-account-admin]
@@ -30,33 +31,61 @@ To do this, follow these steps:
    aws_session_token = <MY_SESSION_TOKEN>
    ```
 
-1. Ensure that the bucket name in `backend.tf` is correct.  It should match
-   the `state_bucket_name` specified in the `tfvars` file that you used to
-   bootstrap the [`cool-accounts/terraform`](../terraform) directory.
-1. Run the command `terraform init -upgrade`.  Note that if you have previously
-   used a different Terraform backend (e.g. for a different environment), you
-   will need to run `terraform init -reconfigure -upgrade`.
+1. Create a backend configuration file named `dev.tfconfig` containing the name
+   of the bucket where Terraform state is stored for that environment.  The
+   bucket name should match the `state_bucket_name` specified in the `tfvars`
+   file that you used to bootstrap the [`cool-accounts/terraform`](../terraform)
+   directory.  This file is required to initialize the Terraform backend in each
+   environment:
+
+    ```hcl
+    bucket = "my-dev-terraform-state-bucket"
+    ```
+
+1. Initialize the Terraform backend for the "dev" environment using your backend
+   configuration file:
+
+    ```console
+    terraform init -upgrade -backend-config=dev.tfconfig
+    ```
+
+    > [!NOTE] When performing this step for additional environments (i.e. not
+    > your first environment), use the `-reconfigure` flag:
+    >
+    > ```console
+    > terraform init -upgrade -backend-config=other-env.tfconfig -reconfigure
+    > ```
+
 1. Create a Terraform workspace (if you haven't already done so) by running
-   `terraform workspace new <workspace_name>`
-1. Create a `<workspace_name>.tfvars` file with any optional variables
-   that you wish to override (see [Inputs](#inputs) below for
-   details):
+   `terraform workspace new dev`
+1. Create a `dev.tfvars` file with any optional variables that you wish to
+   override (see [Inputs](#inputs) below for details):
 
    ```console
    tags = {
      Team        = "VM Fusion - Development"
      Application = "COOL - DNS Account"
-     Workspace   = "production"
+     Workspace   = "dev"
    }
    ```
 
-1. Run the command `terraform apply -var-file=<workspace_name>.tfvars`.
+1. Run the command `terraform apply -var-file=dev.tfvars`.
 1. Revert the changes you made to `providers.tf` in step 1.
-1. Run the command `terraform apply -var-file=<workspace_name>.tfvars`.
+1. If you haven't already done so, create a new AWS profile called
+   `cool-dns-provisionaccount` in your local configuration that includes the
+   `provisionaccount_role` ARN output from the previous step, for example:
 
-At this point the account has been bootstrapped, and you can apply
-future changes by simply running `terraform apply
--var-file=<workspace_name>.tfvars`.
+   ```ini
+   [cool-dns-provisionaccount]
+   role_arn = arn:aws:iam::111111111111:role/ProvisionAccount
+   role_session_name = your.session.name
+   source_profile = cool-user-base-profile
+   ```
+
+1. Run the command `terraform apply -var-file=dev.tfvars`.
+
+At this point the account has been bootstrapped, and you can apply future
+changes by simply running `terraform apply -var-file=dev.tfvars`.
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements ##

--- a/dns/backend.tf
+++ b/dns/backend.tf
@@ -1,6 +1,10 @@
 terraform {
   backend "s3" {
-    bucket         = "cisa-cool-terraform-state"
+    # Use a partial configuration to avoid hardcoding the bucket name. This
+    # allows the bucket name to be set on a per-environment basis via the
+    # -backend-config command line option or other methods.  For details, see:
+    # https://developer.hashicorp.com/terraform/language/backend#partial-configuration
+    bucket         = ""
     dynamodb_table = "terraform-state-lock"
     encrypt        = true
     key            = "cool-accounts/dns.tfstate"

--- a/dynamic/README.md
+++ b/dynamic/README.md
@@ -1,31 +1,31 @@
 # cool-accounts - dynamic subdirectory #
 
-This subdirectory contains Terraform code to provision a dynamic
-(i.e. non-static) COOL account.  It creates an IAM role that allows
-sufficient permissions to provision all AWS resources in the account.
-This role has a trust relationship with the Users account.
+This subdirectory contains Terraform code to provision a dynamic (i.e.
+non-static) COOL account.  It creates an IAM role that allows sufficient
+permissions to provision all AWS resources in the account. This role has a trust
+relationship with the Users account.
 
 ## Bootstrapping this account ##
 
-Note that the dynamic account must be bootstrapped.  This is because
-there is no IAM role that can be assumed to build out these resources.
-Therefore you must first apply this Terraform code with programmatic
-credentials for AWSAdministratorAccess as obtained for the dynamic
-COOL account from the AWS SSO page.
+Note that the dynamic account must be bootstrapped.  This is because there is no
+IAM role that can be assumed to build out these resources. Therefore you must
+first apply this Terraform code with programmatic credentials for
+AWSAdministratorAccess as obtained for the dynamic COOL account from the AWS SSO
+page.
 
-To do this, follow these steps:
+To do this, follow these steps (for the purposes of these instructions, assume
+the environment is named "dev"; replace "dev" in the instructions below with
+your environment name if needed):
 
 1. Comment out the `profile =
-   "cool-${var.dynamic_account_name}-provisionaccount"` line for the
-   "default" provider in `providers.tf` and directly below that
-   uncomment the line `profile =
-   "cool-${var.dynamic_account_name}-account-admin"`.
-1. Create a new AWS profile called
-   `cool-<DYNAMIC_ACCOUNT_NAME>-account-admin` (replacing
-   `<DYNAMIC_ACCOUNT_NAME>` with the actual name of the account) in
-   your Boto3 configuration using the "AWSAdministratorAccess"
-   credentials (access key ID, secret access key, and session token)
-   as obtained from the COOL dynamic account:
+   "cool-${var.dynamic_account_name}-provisionaccount"` line for the "default"
+   provider in `providers.tf` and directly below that uncomment the line
+   `profile = "cool-${var.dynamic_account_name}-account-admin"`.
+1. Create a new AWS profile called `cool-<DYNAMIC_ACCOUNT_NAME>-account-admin`
+   (replacing `<DYNAMIC_ACCOUNT_NAME>` with the actual name of the account) in
+   your Boto3 configuration using the "AWSAdministratorAccess" credentials
+   (access key ID, secret access key, and session token) as obtained from the
+   COOL dynamic account:
 
    ```console
    [cool-<DYNAMIC_ACCOUNT_NAME>-account-admin]
@@ -34,37 +34,69 @@ To do this, follow these steps:
    aws_session_token = <MY_SESSION_TOKEN>
    ```
 
-1. Ensure that the bucket name in `backend.tf` is correct.  It should match
-   the `state_bucket_name` specified in the `tfvars` file that you used to
-   bootstrap the [`cool-accounts/terraform`](../terraform) directory.
-1. Run the command `terraform init -upgrade`.  Note that if you have previously
-   used a different Terraform backend (e.g. for a different environment), you
-   will need to run `terraform init -reconfigure -upgrade`.
-1. Create a Terraform workspace (if you haven't already done so) by
-   running `terraform workspace new <workspace_name>`
-1. Create a `<workspace_name>.tfvars` file in
-   [cisagov/cool-tf-vars](https://github.com/cisagov/cool-tf-vars)
-   with all of the required variables (see [Inputs](#inputs) below for
-   details):
+1. Create a backend configuration file named `dev.tfconfig` containing the name
+   of the bucket where Terraform state is stored for that environment.  The
+   bucket name should match the `state_bucket_name` specified in the `tfvars`
+   file that you used to bootstrap the [`cool-accounts/terraform`](../terraform)
+   directory.  This file is required to initialize the Terraform backend in each
+   environment:
+
+    ```hcl
+    bucket = "my-dev-terraform-state-bucket"
+    ```
+
+1. Initialize the Terraform backend for the "dev" environment using your backend
+   configuration file:
+
+    ```console
+    terraform init -upgrade -backend-config=dev.tfconfig
+    ```
+
+    > [!NOTE] When performing this step for additional environments (i.e. not
+    > your first environment), use the `-reconfigure` flag:
+    >
+    > ```console
+    > terraform init -upgrade -backend-config=other-env.tfconfig -reconfigure
+    > ```
+
+1. Create a Terraform workspace (if you haven't already done so) by running
+   `terraform workspace new <DYNAMIC_ACCOUNT_NAME>-dev`
+1. Create a `<DYNAMIC_ACCOUNT_NAME>-dev.tfvars` file in
+   [cisagov/cool-tf-vars](https://github.com/cisagov/cool-tf-vars) with all of
+   the required variables (see [Inputs](#inputs) below for details):
 
    ```console
    dynamic_account_name = "env0"
 
    tags = {
-     Application       = "COOL - env0 Production Account"
+     Application       = "COOL - env0 Dev Account"
      AssessmentAccount = "true"
      Team              = "VM Fusion - Development"
-     Workspace         = "env0-production"
+     Workspace         = "env0-dev"
    }
    ```
 
-1. Run the command `terraform apply -var-file=<workspace_name>.tfvars`.
+1. Run the command `terraform apply
+   -var-file=<DYNAMIC_ACCOUNT_NAME>-dev.tfvars`.
 1. Revert the changes you made to `providers.tf` in step 1.
-1. Run the command `terraform apply -var-file=<workspace_name>.tfvars`.
+1. If you haven't already done so, create a new AWS profile called
+   `cool-<DYNAMIC_ACCOUNT_NAME>-provisionaccount` in your local configuration
+   that includes the `provisionaccount_role` ARN output from the previous step,
+   for example:
 
-At this point the account has been bootstrapped, and you can apply
-future changes by simply running `terraform apply
--var-file=<workspace_name>.tfvars`.
+   ```ini
+   [cool-<DYNAMIC_ACCOUNT_NAME>-provisionaccount]
+   role_arn = arn:aws:iam::111111111111:role/ProvisionAccount
+   role_session_name = your.session.name
+   source_profile = cool-user-base-profile
+   ```
+
+1. Run the command `terraform apply
+   -var-file=<DYNAMIC_ACCOUNT_NAME>-dev.tfvars`.
+
+At this point the account has been bootstrapped, and you can apply future
+changes by simply running `terraform apply
+-var-file=<DYNAMIC_ACCOUNT_NAME>-dev.tfvars`.
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements ##

--- a/dynamic/backend.tf
+++ b/dynamic/backend.tf
@@ -1,6 +1,10 @@
 terraform {
   backend "s3" {
-    bucket         = "cisa-cool-terraform-state"
+    # Use a partial configuration to avoid hardcoding the bucket name. This
+    # allows the bucket name to be set on a per-environment basis via the
+    # -backend-config command line option or other methods.  For details, see:
+    # https://developer.hashicorp.com/terraform/language/backend#partial-configuration
+    bucket         = ""
     dynamodb_table = "terraform-state-lock"
     encrypt        = true
     key            = "cool-accounts/dynamic.tfstate"

--- a/images/README.md
+++ b/images/README.md
@@ -1,32 +1,32 @@
 # cool-accounts - images subdirectory #
 
-This subdirectory contains Terraform code to provision the COOL
-Images account.  It creates:
+This subdirectory contains Terraform code to provision the COOL Images account.
+It creates:
 
-- An IAM role that allows sufficient permissions to provision all AWS
-  resources in this account.  This role has a trust relationship with
-  the Users account.
-- An IAM role that allows sufficient permissions to create AWS EC2
-  AMIs in this account.  This role has a trust relationship with the
-  Users account.
+- An IAM role that allows sufficient permissions to provision all AWS resources
+  in this account.  This role has a trust relationship with the Users account.
+- An IAM role that allows sufficient permissions to create AWS EC2 AMIs in this
+  account.  This role has a trust relationship with the Users account.
 
 ## Bootstrapping this account ##
 
-Note that this account must be bootstrapped.  This is because there is
-no IAM role that can be assumed to build out these resources.
-Therefore you must first apply this Terraform code with programmatic
-credentials for AWSAdministratorAccess as obtained for the COOL Images
-account from the AWS SSO page.
+Note that this account must be bootstrapped.  This is because there is no IAM
+role that can be assumed to build out these resources. Therefore you must first
+apply this Terraform code with programmatic credentials for
+AWSAdministratorAccess as obtained for the COOL Images account from the AWS SSO
+page.
 
-To do this, follow these steps:
+To do this, follow these steps (for the purposes of these instructions, assume
+the environment is named "dev"; replace "dev" in the instructions below with
+your environment name if needed):
 
-1. Comment out the `profile = "cool-images-provisionaccount"` line for
-   the "default" provider in `providers.tf` and directly below that
-   uncomment the line `profile = "cool-images-account-admin"`.
-1. Create a new AWS profile called `cool-images-account-admin`
-   in your Boto3 configuration using the "AWSAdministratorAccess"
-   credentials (access key ID, secret access key, and session token)
-   as obtained from the COOL Images account:
+1. Comment out the `profile = "cool-images-provisionaccount"` line for the
+   "default" provider in `providers.tf` and directly below that uncomment the
+   line `profile = "cool-images-account-admin"`.
+1. Create a new AWS profile called `cool-images-account-admin` in your Boto3
+   configuration using the "AWSAdministratorAccess" credentials (access key ID,
+   secret access key, and session token) as obtained from the COOL Images
+   account:
 
    ```console
    [cool-images-account-admin]
@@ -35,33 +35,61 @@ To do this, follow these steps:
    aws_session_token = <MY_SESSION_TOKEN>
    ```
 
-1. Ensure that the bucket name in `backend.tf` is correct.  It should match
-   the `state_bucket_name` specified in the `tfvars` file that you used to
-   bootstrap the [`cool-accounts/terraform`](../terraform) directory.
-1. Run the command `terraform init -upgrade`.  Note that if you have previously
-   used a different Terraform backend (e.g. for a different environment), you
-   will need to run `terraform init -reconfigure -upgrade`.
+1. Create a backend configuration file named `dev.tfconfig` containing the name
+   of the bucket where Terraform state is stored for that environment.  The
+   bucket name should match the `state_bucket_name` specified in the `tfvars`
+   file that you used to bootstrap the [`cool-accounts/terraform`](../terraform)
+   directory.  This file is required to initialize the Terraform backend in each
+   environment:
+
+    ```hcl
+    bucket = "my-dev-terraform-state-bucket"
+    ```
+
+1. Initialize the Terraform backend for the "dev" environment using your backend
+   configuration file:
+
+    ```console
+    terraform init -upgrade -backend-config=dev.tfconfig
+    ```
+
+    > [!NOTE] When performing this step for additional environments (i.e. not
+    > your first environment), use the `-reconfigure` flag:
+    >
+    > ```console
+    > terraform init -upgrade -backend-config=other-env.tfconfig -reconfigure
+    > ```
+
 1. Create a Terraform workspace (if you haven't already done so) by running
-   `terraform workspace new <workspace_name>`
-1. Create a `<workspace_name>.tfvars` file with any optional variables
-   that you wish to override (see [Inputs](#inputs) below for
-   details):
+   `terraform workspace new dev`
+1. Create a `dev.tfvars` file with any optional variables that you wish to
+   override (see [Inputs](#inputs) below for details):
 
    ```console
    tags = {
      Team        = "VM Fusion - Development"
      Application = "COOL - Images Account"
-     Workspace   = "production"
+     Workspace   = "dev"
    }
    ```
 
-1. Run the command `terraform apply -var-file=<workspace_name>.tfvars`.
+1. Run the command `terraform apply -var-file=dev.tfvars`.
 1. Revert the changes you made to `providers.tf` in step 1.
-1. Run the command `terraform apply -var-file=<workspace_name>.tfvars`.
+1. If you haven't already done so, create a new AWS profile called
+   `cool-images-provisionaccount` in your local configuration that includes the
+   `provisionaccount_role` ARN output from the previous step, for example:
 
-At this point the account has been bootstrapped, and you can apply
-future changes by simply running `terraform apply
--var-file=<workspace_name>.tfvars`.
+   ```ini
+   [cool-images-provisionaccount]
+   role_arn = arn:aws:iam::111111111111:role/ProvisionAccount
+   role_session_name = your.session.name
+   source_profile = cool-user-base-profile
+   ```
+
+1. Run the command `terraform apply -var-file=dev.tfvars`.
+
+At this point the account has been bootstrapped, and you can apply future
+changes by simply running `terraform apply -var-file=dev.tfvars`.
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements ##

--- a/images/backend.tf
+++ b/images/backend.tf
@@ -1,6 +1,10 @@
 terraform {
   backend "s3" {
-    bucket         = "cisa-cool-terraform-state"
+    # Use a partial configuration to avoid hardcoding the bucket name. This
+    # allows the bucket name to be set on a per-environment basis via the
+    # -backend-config command line option or other methods.  For details, see:
+    # https://developer.hashicorp.com/terraform/language/backend#partial-configuration
+    bucket         = ""
     dynamodb_table = "terraform-state-lock"
     encrypt        = true
     key            = "cool-accounts/images.tfstate"

--- a/log-archive/README.md
+++ b/log-archive/README.md
@@ -1,27 +1,29 @@
 # cool-accounts - log-archive subdirectory #
 
-This subdirectory contains Terraform code to provision the COOL Log
-Archive account.  It creates an IAM role that allows sufficient
-permissions to provision all AWS resources in this account.  This role
-has a trust relationship with the Users account.
+This subdirectory contains Terraform code to provision the COOL Log Archive
+account.  It creates an IAM role that allows sufficient permissions to provision
+all AWS resources in this account.  This role has a trust relationship with the
+Users account.
 
 ## Bootstrapping this account ##
 
-Note that this account must be bootstrapped.  This is because there is
-no IAM role that can be assumed to build out these resources.
-Therefore you must first apply this Terraform code with programmatic
-credentials for AWSAdministratorAccess as obtained for the COOL Log
-Archive account from the AWS SSO page.
+Note that this account must be bootstrapped.  This is because there is no IAM
+role that can be assumed to build out these resources. Therefore you must first
+apply this Terraform code with programmatic credentials for
+AWSAdministratorAccess as obtained for the COOL Log Archive account from the AWS
+SSO page.
 
-To do this, follow these steps:
+To do this, follow these steps (for the purposes of these instructions, assume
+the environment is named "dev"; replace "dev" in the instructions below with
+your environment name if needed):
 
-1. Comment out the `profile = "cool-logarchive-provisionaccount"` line
-   for the "default" provider in `providers.tf` and directly below
-   that uncomment the line `profile = "cool-logarchive-account-admin"`.
-1. Create a new AWS profile called `cool-logarchive-account-admin`
-   in your Boto3 configuration using the "AWSAdministratorAccess"
-   credentials (access key ID, secret access key, and session token)
-   as obtained from the COOL Log Archive account:
+1. Comment out the `profile = "cool-logarchive-provisionaccount"` line for the
+   "default" provider in `providers.tf` and directly below that uncomment the
+   line `profile = "cool-logarchive-account-admin"`.
+1. Create a new AWS profile called `cool-logarchive-account-admin` in your Boto3
+   configuration using the "AWSAdministratorAccess" credentials (access key ID,
+   secret access key, and session token) as obtained from the COOL Log Archive
+   account:
 
    ```console
    [cool-logarchive-account-admin]
@@ -30,15 +32,35 @@ To do this, follow these steps:
    aws_session_token = <MY_SESSION_TOKEN>
    ```
 
-1. Ensure that the bucket name in `backend.tf` is correct.  It should match
-   the `state_bucket_name` specified in the `tfvars` file that you used to
-   bootstrap the [`cool-accounts/terraform`](../terraform) directory.
-1. Run the command `terraform init -upgrade`.  Note that if you have previously
-   used a different Terraform backend (e.g. for a different environment), you
-   will need to run `terraform init -reconfigure -upgrade`.
+1. Create a backend configuration file named `dev.tfconfig` containing the name
+   of the bucket where Terraform state is stored for that environment.  The bucket
+   name should match the `state_bucket_name` specified in the `tfvars` file that
+   you used to bootstrap the [`cool-accounts/terraform`](../terraform)
+   directory.  This file is required to initialize the Terraform backend in each
+   environment:
+
+    ```hcl
+    bucket = "my-dev-terraform-state-bucket"
+    ```
+
+1. Initialize the Terraform backend for the "dev" environment using your backend
+   configuration file:
+
+    ```console
+    terraform init -upgrade -backend-config=dev.tfconfig
+    ```
+
+    > [!NOTE]
+    > When performing this step for additional environments (i.e. not your first
+    > environment), use the `-reconfigure` flag:
+    >
+    > ```console
+    > terraform init -upgrade -backend-config=other-env.tfconfig -reconfigure
+    > ```
+
 1. Create a Terraform workspace (if you haven't already done so) by running
-   `terraform workspace new <workspace_name>`
-1. Create a `<workspace_name>.tfvars` file with any optional variables
+   `terraform workspace new dev`
+1. Create a `dev.tfvars` file with any optional variables
    that you wish to override (see [Inputs](#inputs) below for
    details):
 
@@ -46,17 +68,27 @@ To do this, follow these steps:
    tags = {
      Team        = "VM Fusion - Development"
      Application = "COOL - Log Archive Account"
-     Workspace   = "production"
+     Workspace   = "dev"
    }
    ```
 
-1. Run the command `terraform apply -var-file=<workspace_name>.tfvars`.
+1. Run the command `terraform apply -var-file=dev.tfvars`.
 1. Revert the changes you made to `providers.tf` in step 1.
-1. Run the command `terraform apply -var-file=<workspace_name>.tfvars`.
+1. If you haven't already done so, create a new AWS profile called
+   `cool-logarchive-provisionaccount` in your local configuration that includes the
+   `provisionaccount_role` ARN output from the previous step, for example:
 
-At this point the account has been bootstrapped, and you can apply
-future changes by simply running `terraform apply
--var-file=<workspace_name>.tfvars`.
+   ```ini
+   [cool-logarchive-provisionaccount]
+   role_arn = arn:aws:iam::111111111111:role/ProvisionAccount
+   role_session_name = your.session.name
+   source_profile = cool-user-base-profile
+   ```
+
+1. Run the command `terraform apply -var-file=dev.tfvars`.
+
+At this point the account has been bootstrapped, and you can apply future
+changes by simply running `terraform apply -var-file=dev.tfvars`.
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements ##

--- a/log-archive/backend.tf
+++ b/log-archive/backend.tf
@@ -1,6 +1,10 @@
 terraform {
   backend "s3" {
-    bucket         = "cisa-cool-terraform-state"
+    # Use a partial configuration to avoid hardcoding the bucket name. This
+    # allows the bucket name to be set on a per-environment basis via the
+    # -backend-config command line option or other methods.  For details, see:
+    # https://developer.hashicorp.com/terraform/language/backend#partial-configuration
+    bucket         = ""
     dynamodb_table = "terraform-state-lock"
     encrypt        = true
     key            = "cool-accounts/logarchive.tfstate"

--- a/master/README.md
+++ b/master/README.md
@@ -1,30 +1,29 @@
 # cool-accounts - master subdirectory #
 
-This subdirectory contains Terraform code to provision the COOL
-Master account.  It creates an IAM role that allows sufficient
-permissions to provision all AWS resources in this account.  This role
-has a trust relationship with the Users account.
+This subdirectory contains Terraform code to provision the COOL Master account.
+It creates an IAM role that allows sufficient permissions to provision all AWS
+resources in this account.  This role has a trust relationship with the Users
+account.
 
 ## Bootstrapping this account ##
 
-Note that this account must be bootstrapped.  This is because there is
-no IAM role that can be assumed to build out these resources.
-Therefore you must first apply this Terraform code with programmatic
-credentials for AWSAdministratorAccess as obtained for the COOL Master
-account from the AWS SSO page.
+Note that this account must be bootstrapped.  This is because there is no IAM
+role that can be assumed to build out these resources. Therefore you must first
+apply this Terraform code with programmatic credentials for
+AWSAdministratorAccess as obtained for the COOL Master account from the AWS SSO
+page.
 
-To do this, follow these steps:
+To do this, follow these steps (for the purposes of these instructions, assume
+the environment is named "dev"; replace "dev" in the instructions below with
+your environment name if needed):
 
-1. Comment out the `profile = "cool-master-provisionaccount"` line for
-   the "default" provider in `providers.tf` and directly below that
-   uncomment the line `profile = "cool-master-account-admin"`.
-1. Comment out the `profile = "cool-master-organizationsreadonly"` line for
-   the "organizationsreadonly" provider in `providers.tf` and directly below
-   that uncomment the line `profile = "cool-master-account-admin"`.
-1. Create a new AWS profile called `cool-master-account-admin`
-   in your Boto3 configuration using the "AWSAdministratorAccess"
-   credentials (access key ID, secret access key, and session token)
-   as obtained from the COOL Master account:
+1. Comment out the `profile = "cool-master-provisionaccount"` line for the
+   "default" provider in `providers.tf` and directly below that uncomment the
+   line `profile = "cool-master-account-admin"`.
+1. Create a new AWS profile called `cool-master-account-admin` in your Boto3
+   configuration using the "AWSAdministratorAccess" credentials (access key ID,
+   secret access key, and session token) as obtained from the COOL Master
+   account:
 
    ```console
    [cool-master-account-admin]
@@ -33,15 +32,35 @@ To do this, follow these steps:
    aws_session_token = <MY_SESSION_TOKEN>
    ```
 
-1. Ensure that the bucket name in `backend.tf` is correct.  It should match
-   the `state_bucket_name` specified in the `tfvars` file that you used to
-   bootstrap the [`cool-accounts/terraform`](../terraform) directory.
-1. Run the command `terraform init -upgrade`.  Note that if you have previously
-   used a different Terraform backend (e.g. for a different environment), you
-   will need to run `terraform init -reconfigure -upgrade`.
+1. Create a backend configuration file named `dev.tfconfig` containing the name
+   of the bucket where Terraform state is stored for that environment.  The bucket
+   name should match the `state_bucket_name` specified in the `tfvars` file that
+   you used to bootstrap the [`cool-accounts/terraform`](../terraform)
+   directory.  This file is required to initialize the Terraform backend in each
+   environment:
+
+    ```hcl
+    bucket = "my-dev-terraform-state-bucket"
+    ```
+
+1. Initialize the Terraform backend for the "dev" environment using your backend
+   configuration file:
+
+    ```console
+    terraform init -upgrade -backend-config=dev.tfconfig
+    ```
+
+    > [!NOTE]
+    > When performing this step for additional environments (i.e. not your first
+    > environment), use the `-reconfigure` flag:
+    >
+    > ```console
+    > terraform init -upgrade -backend-config=other-env.tfconfig -reconfigure
+    > ```
+
 1. Create a Terraform workspace (if you haven't already done so) by running
-   `terraform workspace new <workspace_name>`
-1. Create a `<workspace_name>.tfvars` file with any optional variables
+   `terraform workspace new dev`
+1. Create a `dev.tfvars` file with any optional variables
    that you wish to override (see [Inputs](#inputs) below for
    details):
 
@@ -49,17 +68,27 @@ To do this, follow these steps:
    tags = {
      Team        = "VM Fusion - Development"
      Application = "COOL - Master Account"
-     Workspace   = "production"
+     Workspace   = "dev"
    }
    ```
 
-1. Run the command `terraform apply -var-file=<workspace_name>.tfvars`.
-1. Revert the changes you made to `providers.tf` in steps 1 and 2.
-1. Run the command `terraform apply -var-file=<workspace_name>.tfvars`.
+1. Run the command `terraform apply -var-file=dev.tfvars`.
+1. Revert the changes you made to `providers.tf` in step 1.
+1. If you haven't already done so, create a new AWS profile called
+   `cool-master-provisionaccount` in your local configuration that includes the
+   `provisionaccount_role` ARN output from the previous step, for example:
 
-At this point the account has been bootstrapped, and you can apply
-future changes by simply running `terraform apply
--var-file=<workspace_name>.tfvars`.
+   ```ini
+   [cool-master-provisionaccount]
+   role_arn = arn:aws:iam::111111111111:role/ProvisionAccount
+   role_session_name = your.session.name
+   source_profile = cool-user-base-profile
+   ```
+
+1. Run the command `terraform apply -var-file=dev.tfvars`.
+
+At this point the account has been bootstrapped, and you can apply future
+changes by simply running `terraform apply -var-file=dev.tfvars`.
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements ##

--- a/master/backend.tf
+++ b/master/backend.tf
@@ -1,6 +1,10 @@
 terraform {
   backend "s3" {
-    bucket         = "cisa-cool-terraform-state"
+    # Use a partial configuration to avoid hardcoding the bucket name. This
+    # allows the bucket name to be set on a per-environment basis via the
+    # -backend-config command line option or other methods.  For details, see:
+    # https://developer.hashicorp.com/terraform/language/backend#partial-configuration
+    bucket         = ""
     dynamodb_table = "terraform-state-lock"
     encrypt        = true
     key            = "cool-accounts/master.tfstate"

--- a/shared-services/README.md
+++ b/shared-services/README.md
@@ -1,28 +1,29 @@
 # cool-accounts - shared-services subdirectory #
 
-This subdirectory contains Terraform code to provision the COOL
-Shared Services account.  It creates an IAM role that allows
-sufficient permissions to provision all AWS resources in this account.
-This role has a trust relationship with the Users account.
+This subdirectory contains Terraform code to provision the COOL Shared Services
+account.  It creates an IAM role that allows sufficient permissions to provision
+all AWS resources in this account. This role has a trust relationship with the
+Users account.
 
 ## Bootstrapping this account ##
 
-Note that this account must be bootstrapped.  This is because there is
-no IAM role that can be assumed to build out these resources.
-Therefore you must first apply this Terraform code with programmatic
-credentials for AWSAdministratorAccess as obtained for the COOL Shared
-Services account from the AWS SSO page.
+Note that this account must be bootstrapped.  This is because there is no IAM
+role that can be assumed to build out these resources. Therefore you must first
+apply this Terraform code with programmatic credentials for
+AWSAdministratorAccess as obtained for the COOL Shared Services account from the
+AWS SSO page.
 
-To do this, follow these steps:
+To do this, follow these steps (for the purposes of these instructions, assume
+the environment is named "dev"; replace "dev" in the instructions below with
+your environment name if needed):
 
-1. Comment out the `profile = "cool-sharedservices-provisionaccount"`
-   line for the "default" provider in `providers.tf` and directly
-   below that uncomment the line `profile =
-   "cool-sharedservices-account-admin"`.
-1. Create a new AWS profile called `cool-sharedservices-account-admin`
-   in your Boto3 configuration using the "AWSAdministratorAccess"
-   credentials (access key ID, secret access key, and session token)
-   as obtained from the COOL Shared Services account:
+1. Comment out the `profile = "cool-sharedservices-provisionaccount"` line for
+   the "default" provider in `providers.tf` and directly below that uncomment
+   the line `profile = "cool-sharedservices-account-admin"`.
+1. Create a new AWS profile called `cool-sharedservices-account-admin` in your
+   Boto3 configuration using the "AWSAdministratorAccess" credentials (access
+   key ID, secret access key, and session token) as obtained from the COOL
+   Shared Services account:
 
    ```console
    [cool-sharedservices-account-admin]
@@ -31,33 +32,62 @@ To do this, follow these steps:
    aws_session_token = <MY_SESSION_TOKEN>
    ```
 
-1. Ensure that the bucket name in `backend.tf` is correct.  It should match
-   the `state_bucket_name` specified in the `tfvars` file that you used to
-   bootstrap the [`cool-accounts/terraform`](../terraform) directory.
-1. Run the command `terraform init -upgrade`.  Note that if you have previously
-   used a different Terraform backend (e.g. for a different environment), you
-   will need to run `terraform init -reconfigure -upgrade`.
+1. Create a backend configuration file named `dev.tfconfig` containing the name
+   of the bucket where Terraform state is stored for that environment.  The
+   bucket name should match the `state_bucket_name` specified in the `tfvars`
+   file that you used to bootstrap the [`cool-accounts/terraform`](../terraform)
+   directory.  This file is required to initialize the Terraform backend in each
+   environment:
+
+    ```hcl
+    bucket = "my-dev-terraform-state-bucket"
+    ```
+
+1. Initialize the Terraform backend for the "dev" environment using your backend
+   configuration file:
+
+    ```console
+    terraform init -upgrade -backend-config=dev.tfconfig
+    ```
+
+    > [!NOTE] When performing this step for additional environments (i.e. not
+    > your first environment), use the `-reconfigure` flag:
+    >
+    > ```console
+    > terraform init -upgrade -backend-config=other-env.tfconfig -reconfigure
+    > ```
+
 1. Create a Terraform workspace (if you haven't already done so) by running
-   `terraform workspace new <workspace_name>`
-1. Create a `<workspace_name>.tfvars` file with any optional variables
-   that you wish to override (see [Inputs](#inputs) below for
-   details):
+   `terraform workspace new dev`
+1. Create a `dev.tfvars` file with any optional variables that you wish to
+   override (see [Inputs](#inputs) below for details):
 
    ```console
    tags = {
      Team        = "VM Fusion - Development"
      Application = "COOL - Shared Services Account"
-     Workspace   = "production"
+     Workspace   = "dev"
    }
    ```
 
-1. Run the command `terraform apply -var-file=<workspace_name>.tfvars`.
+1. Run the command `terraform apply -var-file=dev.tfvars`.
 1. Revert the changes you made to `providers.tf` in step 1.
-1. Run the command `terraform apply -var-file=<workspace_name>.tfvars`.
+1. If you haven't already done so, create a new AWS profile called
+   `cool-sharedservices-provisionaccount` in your local configuration that
+   includes the `provisionaccount_role` ARN output from the previous step, for
+   example:
 
-At this point the account has been bootstrapped, and you can apply
-future changes by simply running `terraform apply
--var-file=<workspace_name>.tfvars`.
+   ```ini
+   [cool-sharedservices-provisionaccount]
+   role_arn = arn:aws:iam::111111111111:role/ProvisionAccount
+   role_session_name = your.session.name
+   source_profile = cool-user-base-profile
+   ```
+
+1. Run the command `terraform apply -var-file=dev.tfvars`.
+
+At this point the account has been bootstrapped, and you can apply future
+changes by simply running `terraform apply -var-file=dev.tfvars`.
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements ##

--- a/shared-services/backend.tf
+++ b/shared-services/backend.tf
@@ -1,6 +1,10 @@
 terraform {
   backend "s3" {
-    bucket         = "cisa-cool-terraform-state"
+    # Use a partial configuration to avoid hardcoding the bucket name. This
+    # allows the bucket name to be set on a per-environment basis via the
+    # -backend-config command line option or other methods.  For details, see:
+    # https://developer.hashicorp.com/terraform/language/backend#partial-configuration
+    bucket         = ""
     dynamodb_table = "terraform-state-lock"
     encrypt        = true
     key            = "cool-accounts/shared_services.tfstate"

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,31 +1,31 @@
 # cool-accounts - terraform subdirectory #
 
-This subdirectory contains Terraform code to provision the COOL
-Terraform account.  It creates:
+This subdirectory contains Terraform code to provision the COOL Terraform
+account.  It creates:
 
 - The S3 bucket used to store Terraform state.
 - The DynamoDB table used for Terraform state locking.
-- An IAM role that allows sufficient access to the Terraform S3 bucket
-  and DynamoDB table to use those resources as a Terraform backend.
-  This role also has a trust relationship with the Users account.
-- An IAM role that allows sufficient permissions to provision all AWS
-  resources in this account.  This role has a trust relationship with
-  the Users account.
+- An IAM role that allows sufficient access to the Terraform S3 bucket and
+  DynamoDB table to use those resources as a Terraform backend. This role also
+  has a trust relationship with the Users account.
+- An IAM role that allows sufficient permissions to provision all AWS resources
+  in this account.  This role has a trust relationship with the Users account.
 
 ## Bootstrapping this account ##
 
-Note that this account must be bootstrapped.  This is because
-initially there are no resources in this account that can be used to
-host remote shared Terraform state, and also because there is no IAM
-role that can be assumed to build out these resources.  Therefore you
-must first apply this Terraform code with:
+Note that this account must be bootstrapped.  This is because initially there
+are no resources in this account that can be used to host remote shared
+Terraform state, and also because there is no IAM role that can be assumed to
+build out these resources.  Therefore you must first apply this Terraform code
+with:
 
 - No backend configuration, so that the state is created locally.
-- Using programmatic credentials for AWSAdministratorAccess as
-  obtained for the COOL Terraform and Users accounts from the AWS SSO
-  page.
+- Using programmatic credentials for AWSAdministratorAccess as obtained for the
+  COOL Terraform and Users accounts from the AWS SSO page.
 
-To do this, follow these steps:
+To do this, follow these steps (for the purposes of these instructions, assume
+the environment is named "dev"; replace "dev" in the instructions below with
+your environment name if needed):
 
 1. Comment out all the content in the `backend.tf` file.
 1. Comment out the `profile = "cool-terraform-provisionaccount"` line
@@ -62,50 +62,71 @@ To do this, follow these steps:
    used a different Terraform backend (e.g. for a different environment), you
    will need to run `terraform init -reconfigure -upgrade`.
 1. Create a Terraform workspace (if you haven't already done so) by running
-   `terraform workspace new <workspace_name>`
-1. Create a `<workspace_name>.tfvars` file with all of the required
+   `terraform workspace new dev`
+1. Create a `dev.tfvars` file with all of the required
    variables and any optional variables that you want to override (see
    [Inputs](#inputs) below for details):
 
    ```hcl
    lambda_bucket_name = "my-lambda-bucket"
    lambda_key         = "disable_inactive_iam_users.zip"
-   state_bucket_name  = "my-terraform-state-bucket"
+   state_bucket_name  = "my-dev-terraform-state-bucket"
 
    tags = {
      Team        = "VM Fusion - Development"
      Application = "COOL - Terraform Account"
-     Workspace   = "production"
+     Workspace   = "dev"
    }
    ```
 
-1. Run the command `terraform apply -var-file=<workspace_name>.tfvars`.
+1. Run the command `terraform apply -var-file=dev.tfvars`.
 1. Revert the changes you made to `backend.tf` in step 1.
-1. Edit the bucket name in `backend.tf` to match the `state_bucket_name`
-   variable in your `<workspace_name>.tfvars` file.
-1. Comment out the `profile = "cool-terraform-backend"` line
-   in `backend.tf` and directly below that uncomment the line
-   `profile = "cool-terraform-account-admin"`.
+1. Comment out the `profile = "cool-terraform-backend"` line in `backend.tf` and
+   directly below that uncomment the line `profile =
+   "cool-terraform-account-admin"`.
 1. Revert the changes you made to `provider.tf` in step 2.  Give yourself
    a reminder to revert the changes you made to `provider.tf` in step 3 after
    you bootstrap the Master account.
-1. Run the command `terraform init`.  When Terraform asks 'Do you want to
-   migrate all workspaces to "s3"?', enter "yes".
-1. Run the command `terraform apply -var-file=<workspace_name>.tfvars`, but
-   note that it will fail because the "disable inactive IAM users" Lambda is
-   not yet present in your newly-created Lambda bucket.
+1. Create a backend configuration file named `dev.tfconfig` containing the name
+   of the bucket where Terraform state is stored for that environment.  The
+   bucket name should match the `state_bucket_name` specified in the
+   `dev.tfvars` file that you created earlier.  This file is required to
+   initialize the Terraform backend in each environment:
+
+    ```hcl
+    bucket = "my-dev-terraform-state-bucket"
+    ```
+
+1. Initialize the Terraform backend for the "dev" environment using your backend
+   configuration file - when Terraform asks 'Do you want to migrate all
+   workspaces to "s3"?', enter "yes":
+
+    ```console
+    terraform init -upgrade -backend-config=dev.tfconfig
+    ```
+
+    > [!NOTE]
+    > When performing this step for additional environments (i.e. not your first
+    > environment), use the `-reconfigure` flag:
+    >
+    > ```console
+    > terraform init -upgrade -backend-config=other-env.tfconfig -reconfigure
+    > ```
+
+1. Run the command `terraform apply -var-file=dev.tfvars`, but note that it will
+   fail because the "disable inactive IAM users" Lambda is not yet present in
+   your newly-created Lambda bucket.
 1. To correct this, follow the instructions in the
    [`cisagov/disable-inactive-iam-users-lambda` README](https://github.com/cisagov/disable-inactive-iam-users-lambda)
    to build a Lambda deployment file (e.g. "disable_inactive_iam_users.zip").
 1. Upload your newly-created Lambda deployment file to your Lambda bucket.
-1. Run the command `terraform apply -var-file=<workspace_name>.tfvars`.
+1. Run the command `terraform apply -var-file=dev.tfvars`.
 
-At this point the account has been bootstrapped, and you can apply
-future changes by simply running `terraform apply
--var-file=<workspace_name>.tfvars`.  You can also now delete the
-`cool-terraform-account-admin` AWS profile that you created in step 4.  Give
-yourself a reminder to revert the changes you made to `backend.tf` in step 12
-after you bootstrap the Users account.
+At this point the account has been bootstrapped, and you can apply future
+changes by simply running `terraform apply -var-file=dev.tfvars`.  You can also
+now delete the `cool-terraform-account-admin` AWS profile that you created in
+step 4.  Give yourself a reminder to revert the changes you made to `backend.tf`
+in step 11 after you bootstrap the Users account.
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements ##

--- a/terraform/backend.tf
+++ b/terraform/backend.tf
@@ -2,7 +2,11 @@
 # account.
 terraform {
   backend "s3" {
-    bucket         = "cisa-cool-terraform-state"
+    # Use a partial configuration to avoid hardcoding the bucket name. This
+    # allows the bucket name to be set on a per-environment basis via the
+    # -backend-config command line option or other methods.  For details, see:
+    # https://developer.hashicorp.com/terraform/language/backend#partial-configuration
+    bucket         = ""
     dynamodb_table = "terraform-state-lock"
     encrypt        = true
     key            = "cool-accounts/terraform.tfstate"

--- a/users/README.md
+++ b/users/README.md
@@ -1,35 +1,37 @@
 # cool-accounts - users subdirectory #
 
-This subdirectory contains Terraform code to provision the COOL
-Users account.  It creates:
+This subdirectory contains Terraform code to provision the COOL Users account.
+It creates:
 
 - IAM user(s) with the ability to administer their own credentials (including
   multi-factor authentication).
-- An IAM group containing the user(s) above.  This group is allowed to
-  access the terraform backend, be an IAM administrator for the Users
-  account, and is allowed to assume any role that has a trust
-  relationship with the Users account.
+- An IAM group containing the user(s) above.  This group is allowed to access
+  the terraform backend, be an IAM administrator for the Users account, and is
+  allowed to assume any role that has a trust relationship with the Users
+  account.
 
 ## Bootstrapping this account ##
 
-Note that this account must be bootstrapped.  This is because because
-there is no IAM role that can be assumed to build out these resources.
-Therefore you must first apply this Terraform code with programmatic
-credentials for AWSAdministratorAccess as obtained for the COOL
-Users account from the AWS SSO page.
+Note that this account must be bootstrapped.  This is because because there is
+no IAM role that can be assumed to build out these resources. Therefore you must
+first apply this Terraform code with programmatic credentials for
+AWSAdministratorAccess as obtained for the COOL Users account from the AWS SSO
+page.
 
-To do this, follow these steps:
+To do this, follow these steps (for the purposes of these instructions, assume
+the environment is named "dev"; replace "dev" in the instructions below with
+your environment name if needed):
 
-1. Comment out the `profile = "cool-users-provisionaccount"` line for
-   the "default" provider in `providers.tf` and directly below that
-   uncomment the line `profile = "cool-users-account-admin"`.
-1. Comment out the `profile = "cool-master-organizationsreadonly"` line
-   for the "organizationsreadonly" provider in `providers.tf` and directly
-   below that uncomment the line `profile = "cool-master-account-admin"`.
-1. Create a new AWS profile called `cool-users-account-admin` in
-   your Boto3 configuration using the "AWSAdministratorAccess"
-   credentials (access key ID, secret access key, and session token)
-   as obtained from the COOL Users account:
+1. Comment out the `profile = "cool-users-provisionaccount"` line for the
+   "default" provider in `providers.tf` and directly below that uncomment the
+   line `profile = "cool-users-account-admin"`.
+1. Comment out the `profile = "cool-master-organizationsreadonly"` line for the
+   "organizationsreadonly" provider in `providers.tf` and directly below that
+   uncomment the line `profile = "cool-master-account-admin"`.
+1. Create a new AWS profile called `cool-users-account-admin` in your Boto3
+   configuration using the "AWSAdministratorAccess" credentials (access key ID,
+   secret access key, and session token) as obtained from the COOL Users
+   account:
 
    ```console
    [cool-users-account-admin]
@@ -38,10 +40,10 @@ To do this, follow these steps:
    aws_session_token = <MY_SESSION_TOKEN>
    ```
 
-1. Create a new AWS profile called `cool-master-account-admin` in
-   your Boto3 configuration using the "AWSAdministratorAccess"
-   credentials (access key ID, secret access key, and session token)
-   as obtained from the COOL Master account:
+1. Create a new AWS profile called `cool-master-account-admin` in your Boto3
+   configuration using the "AWSAdministratorAccess" credentials (access key ID,
+   secret access key, and session token) as obtained from the COOL Master
+   account:
 
    ```console
    [cool-master-account-admin]
@@ -50,10 +52,10 @@ To do this, follow these steps:
    aws_session_token = <MY_SESSION_TOKEN>
    ```
 
-1. Create a new AWS profile called `cool-terraform-account-admin` in
-   your Boto3 configuration using the "AWSAdministratorAccess"
-   credentials (access key ID, secret access key, and session token)
-   as obtained from the COOL Terraform account:
+1. Create a new AWS profile called `cool-terraform-account-admin` in your Boto3
+   configuration using the "AWSAdministratorAccess" credentials (access key ID,
+   secret access key, and session token) as obtained from the COOL Terraform
+   account:
 
    ```console
    [cool-terraform-account-admin]
@@ -62,20 +64,50 @@ To do this, follow these steps:
    aws_session_token = <MY_SESSION_TOKEN>
    ```
 
-1. Ensure that the bucket name in `backend.tf` is correct.  It should match
-   the `state_bucket_name` specified in the `tfvars` file that you used to
-   bootstrap the [`cool-accounts/terraform`](../terraform) directory.
-1. Comment out the `profile = "cool-terraform-backend"` line
-   in `backend.tf` and directly below that uncomment the line
-   `profile = "cool-terraform-account-admin"`.
-1. Run the command `terraform init -upgrade`.  Note that if you have previously
-   used a different Terraform backend (e.g. for a different environment), you
-   will need to run `terraform init -reconfigure -upgrade`.
+1. Create a backend configuration file named `dev.tfconfig` containing the name
+   of the bucket where Terraform state is stored for that environment.  It
+   should match the `state_bucket_name` specified in the `tfvars` file that you
+   used to bootstrap the [`cool-accounts/terraform`](../terraform) directory.
+   This file is required to initialize the Terraform backend in each
+   environment:
+
+    ```hcl
+    bucket = "my-dev-terraform-state-bucket"
+    ```
+
+1. Comment out the `profile = "cool-terraform-backend"` line in `backend.tf` and
+   directly below that uncomment the line `profile =
+   "cool-terraform-account-admin"`.
+1. Create a backend configuration file named `dev.tfconfig` containing the name
+   of the bucket where Terraform state is stored for that environment.  The
+   bucket name should match the `state_bucket_name` specified in the `tfvars`
+   file that you used to bootstrap the [`cool-accounts/terraform`](../terraform)
+   directory.  This file is required to initialize the Terraform backend in each
+   environment:
+
+    ```hcl
+    bucket = "my-dev-terraform-state-bucket"
+    ```
+
+1. Initialize the Terraform backend for the "dev" environment using your backend
+   configuration file:
+
+    ```console
+    terraform init -upgrade -backend-config=dev.tfconfig
+    ```
+
+    > [!NOTE] When performing this step for additional environments (i.e. not
+    > your first environment), use the `-reconfigure` flag:
+    >
+    > ```console
+    > terraform init -upgrade -backend-config=other-env.tfconfig -reconfigure
+    > ```
+
 1. Create a Terraform workspace (if you haven't already done so) by running
-   `terraform workspace new <workspace_name>`
-1. Create a `<workspace_name>.tfvars` file with all of the required
-   variables and any optional variables that you want to override (see
-   [Inputs](#inputs) below for details):
+   `terraform workspace new dev`
+1. Create a `dev.tfvars` file with all of the required variables and any
+   optional variables that you want to override (see [Inputs](#inputs) below for
+   details):
 
    ```console
    godlike_usernames = [
@@ -85,27 +117,25 @@ To do this, follow these steps:
    tags = {
      Team        = "VM Fusion - Development"
      Application = "COOL - Users Account"
-     Workspace   = "production"
+     Workspace   = "dev"
    }
    ```
 
-1. Run the command `terraform apply -var-file=<workspace_name>.tfvars`.
+1. Run the command `terraform apply -var-file=dev.tfvars`.
 1. Login (using the AWS web console) to the Users account via SSO with
    AWSAdministratorAccess.
 1. Locate your newly-created IAM user account and create an access key.
 1. Copy your new access key ID and secret access key into your AWS credentials
    file.
-1. Revert the changes you made to `provider.tf` in step 1.  Give yourself
-   a reminder to revert the changes you made to `provider.tf` in step 2 after
-   you bootstrap the Master account.
+1. Revert the changes you made to `provider.tf` in step 1.  Give yourself a
+   reminder to revert the changes you made to `provider.tf` in step 2 after you
+   bootstrap the Master account.
 1. Revert the changes you made to `backend.tf` in step 7.
-1. Run the command `terraform init -migrate-state`.  When Terraform asks 'Do
-   you want to migrate all workspaces to "s3"?', enter "yes".
-1. Run the command `terraform apply -var-file=<workspace_name>.tfvars`.
+1. Run the command `terraform init -reconfigure`.
+1. Run the command `terraform apply -var-file=dev.tfvars`.
 
-At this point the account has been bootstrapped, and you can apply
-future changes by simply running `terraform apply
--var-file=<workspace_name>.tfvars`.
+At this point the account has been bootstrapped, and you can apply future
+changes by simply running `terraform apply -var-file=dev.tfvars`.
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements ##

--- a/users/README.md
+++ b/users/README.md
@@ -64,17 +64,6 @@ your environment name if needed):
    aws_session_token = <MY_SESSION_TOKEN>
    ```
 
-1. Create a backend configuration file named `dev.tfconfig` containing the name
-   of the bucket where Terraform state is stored for that environment.  It
-   should match the `state_bucket_name` specified in the `tfvars` file that you
-   used to bootstrap the [`cool-accounts/terraform`](../terraform) directory.
-   This file is required to initialize the Terraform backend in each
-   environment:
-
-    ```hcl
-    bucket = "my-dev-terraform-state-bucket"
-    ```
-
 1. Comment out the `profile = "cool-terraform-backend"` line in `backend.tf` and
    directly below that uncomment the line `profile =
    "cool-terraform-account-admin"`.

--- a/users/backend.tf
+++ b/users/backend.tf
@@ -2,7 +2,11 @@
 # account.
 terraform {
   backend "s3" {
-    bucket         = "cisa-cool-terraform-state"
+    # Use a partial configuration to avoid hardcoding the bucket name. This
+    # allows the bucket name to be set on a per-environment basis via the
+    # -backend-config command line option or other methods.  For details, see:
+    # https://developer.hashicorp.com/terraform/language/backend#partial-configuration
+    bucket         = ""
     dynamodb_table = "terraform-state-lock"
     encrypt        = true
     key            = "cool-accounts/users.tfstate"


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR makes updates in support of the switchover from our legacy account/environment scheme (where staging and production accounts exist within the same AWS organization) to our new scheme (where they do not).

In this case, the primary change is the use of [partial backend configurations](https://developer.hashicorp.com/terraform/language/backend#partial-configuration).  I also updated the READMEs to include updated bootstrapping instructions.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

The goal of this PR is to get us closer to our modernized account scheme where there is no more co-mingling of staging and production accounts.  Doing that will result in cleaner code across all COOL-related repositories as well as improved separation of resources across all COOL environments. 

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I successfully applied the Terraform in each subdirectory in dev-a, staging-a, and production environments and everything looks as expected.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.
