### PR TITLE
Share AMI KMS key with Terraformer role in extraorg_account_ids

### DIFF
--- a/images/ami_kms_key.tf
+++ b/images/ami_kms_key.tf
@@ -121,6 +121,9 @@ data "aws_iam_policy_document" "ami_kms_doc" {
         ], [
         for account_id in var.extraorg_account_ids :
         "arn:aws:iam::${account_id}:role/ProvisionAccount"
+        ], [
+        for account_id in var.extraorg_account_ids :
+        "arn:aws:iam::${account_id}:role/Terraformer"
       ])
       variable = "aws:PrincipalArn"
     }


### PR DESCRIPTION

# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR allows the AMI KMS key to be used by the Terraformer role in any accounts specified in `var.extraorg_account_ids`.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

This was not needed in the past, but is currently needed to give specified non-production environments the ability to use a particular production AMI (our legacy Windows AMI).

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

After applying this Terraform (and related Terraform in https://github.com/cisagov/cool-assessment-terraform/pull/263), a user in a staging environment was able to successfully deploy instances based on the production Windows AMI from the terraformer instance in their staging environment.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
